### PR TITLE
Add Dokka plugin to generate docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
   kotlin("jvm")
+  id("org.jetbrains.dokka")
   id("com.diffplug.spotless")
   id("ru.vyarus.animalsniffer")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@
  * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
  * or LICENSE-MIT files respectively.
  */
-import com.diffplug.gradle.spotless.SpotlessExtension
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
@@ -19,7 +18,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
   kotlinOptions { moduleName = "kage" }
 }
 
-configure<SpotlessExtension> {
+spotless {
   kotlin {
     ktfmt().googleStyle()
     target("**/*.kt")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,8 @@ spotless {
   }
 }
 
+tasks.check { finalizedBy(tasks.dokkaHtml) }
+
 sourceSets { named("main") { java.srcDirs("src/kotlin") } }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,8 @@ pluginManagement {
     mavenCentral()
   }
   plugins {
-    id("org.jetbrains.kotlin.jvm") version "$kotlinVersion"
+    id("org.jetbrains.kotlin.jvm") version kotlinVersion
+    id("org.jetbrains.dokka") version kotlinVersion
     id("com.diffplug.spotless") version "6.1.0"
     id("ru.vyarus.animalsniffer") version "1.5.4" apply false
   }


### PR DESCRIPTION
Adds the Gradle plugin for Dokka to allow generation of docs as well as hooks it up with the `check` task to ensure invalid KDoc is caught by CI