### PR TITLE
Cleanup Gradle build to consistently use Version Catalogs everywhere

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,12 @@
  */
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
+@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
-  kotlin("jvm")
-  id("org.jetbrains.dokka")
-  id("com.diffplug.spotless")
-  id("ru.vyarus.animalsniffer")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.dokka)
+  alias(libs.plugins.spotless)
+  alias(libs.plugins.animalsniffer)
 }
 
 kotlin { explicitApi() }
@@ -37,8 +38,8 @@ tasks.check { finalizedBy(tasks.dokkaHtml) }
 sourceSets { named("main") { java.srcDirs("src/kotlin") } }
 
 dependencies {
-  signature("net.sf.androidscents.signature:android-api-level-23:6.0_r3")
-  implementation("at.favre.lib:hkdf:1.1.0")
+  signature(libs.animalsniffer.signature.android)
+  implementation(libs.hkdf)
   testImplementation(libs.kotlintest.junit)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,8 @@
  */
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
+// Workaround for false-positive IDE errors
+// From https://youtrack.jetbrains.com/issue/KTIJ-19369#focus=Comments-27-5181027.0-0
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
   alias(libs.plugins.kotlin.jvm)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,13 @@
 [versions]
-kotlin = "1.5.21"
+kotlin = "1.6.10"
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "kotlin" }
+spotless = { id = "com.diffplug.spotless", version = "6.1.0" }
+animalsniffer = { id = "ru.vyarus.animalsniffer", version = "1.5.4" }
 
 [libraries]
+animalsniffer-signature-android = "net.sf.androidscents.signature:android-api-level-23:6.0_r3"
+hkdf = "at.favre.lib:hkdf:1.1.0"
 kotlintest-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,16 +10,9 @@ enableFeaturePreview("VERSION_CATALOGS")
 rootProject.name = "kage"
 
 pluginManagement {
-  val kotlinVersion = "1.6.10"
   repositories {
     gradlePluginPortal()
     mavenCentral()
-  }
-  plugins {
-    id("org.jetbrains.kotlin.jvm") version kotlinVersion
-    id("org.jetbrains.dokka") version kotlinVersion
-    id("com.diffplug.spotless") version "6.1.0"
-    id("ru.vyarus.animalsniffer") version "1.5.4" apply false
   }
 }
 


### PR DESCRIPTION
Updates the Gradle build to move plugins and all dependencies to the Gradle Version Catalogs functionality