### PR TITLE
Rename `AgeKey` to `AgeFile`

### DIFF
--- a/src/kotlin/kage/format/AgeFile.kt
+++ b/src/kotlin/kage/format/AgeFile.kt
@@ -7,11 +7,11 @@ package kage.format
 
 import java.io.BufferedReader
 
-public class AgeKey(public val header: AgeHeader, public val body: ByteArray) {
+public class AgeFile(public val header: AgeHeader, public val body: ByteArray) {
 
   override fun equals(other: Any?): Boolean {
     if (other == null) return false
-    if (other !is AgeKey) return false
+    if (other !is AgeFile) return false
 
     if (this === other) return true
 
@@ -34,7 +34,7 @@ public class AgeKey(public val header: AgeHeader, public val body: ByteArray) {
     internal const val COLUMNS_PER_LINE = 64
     internal const val BYTES_PER_LINE = COLUMNS_PER_LINE / 4 * 3
 
-    internal fun parse(reader: BufferedReader): AgeKey {
+    internal fun parse(reader: BufferedReader): AgeFile {
       val header = AgeHeader.parse(reader)
       TODO("We need to parse the body")
     }

--- a/src/kotlin/kage/format/AgeHeader.kt
+++ b/src/kotlin/kage/format/AgeHeader.kt
@@ -12,9 +12,9 @@ import kage.errors.InvalidFooterException
 import kage.errors.InvalidHMACException
 import kage.errors.InvalidRecipientException
 import kage.errors.InvalidVersionException
-import kage.format.AgeKey.Companion.FOOTER_PREFIX
-import kage.format.AgeKey.Companion.RECIPIENT_PREFIX
-import kage.format.AgeKey.Companion.VERSION_LINE
+import kage.format.AgeFile.Companion.FOOTER_PREFIX
+import kage.format.AgeFile.Companion.RECIPIENT_PREFIX
+import kage.format.AgeFile.Companion.VERSION_LINE
 import kage.format.ParseUtils.splitArgs
 import kage.utils.encodeBase64
 import kage.utils.writeNewLine

--- a/src/kotlin/kage/format/AgeStanza.kt
+++ b/src/kotlin/kage/format/AgeStanza.kt
@@ -10,10 +10,10 @@ import java.io.BufferedWriter
 import java.util.Base64
 import kage.errors.InvalidArbitraryStringException
 import kage.errors.InvalidRecipientException
-import kage.format.AgeKey.Companion.BYTES_PER_LINE
-import kage.format.AgeKey.Companion.COLUMNS_PER_LINE
-import kage.format.AgeKey.Companion.FOOTER_PREFIX
-import kage.format.AgeKey.Companion.RECIPIENT_PREFIX
+import kage.format.AgeFile.Companion.BYTES_PER_LINE
+import kage.format.AgeFile.Companion.COLUMNS_PER_LINE
+import kage.format.AgeFile.Companion.FOOTER_PREFIX
+import kage.format.AgeFile.Companion.RECIPIENT_PREFIX
 import kage.format.ParseUtils.isValidArbitraryString
 import kage.format.ParseUtils.splitArgs
 import kage.utils.encodeBase64


### PR DESCRIPTION
We were using incorrect naming conventions earlier. This PR would fix that by renaming `AgeKey` to `AgeFile`