### PR TITLE
Use X25519Identity and X25519Recipient as public/private key material

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
   signature(libs.animalsniffer.signature.android)
   implementation(libs.hkdf)
   implementation("org.bouncycastle:bcprov-jdk15on:1.70")
+  implementation("com.michael-bull.kotlin-result:kotlin-result:1.1.16")
   testImplementation(libs.kotlintest.junit)
 }
 

--- a/src/kotlin/kage/crypto/x25519/X25519.kt
+++ b/src/kotlin/kage/crypto/x25519/X25519.kt
@@ -8,48 +8,19 @@ package kage.crypto.x25519
 import org.bouncycastle.math.ec.rfc7748.X25519
 
 public object X25519 {
-  public val BASEPOINT: ByteArray =
-    byteArrayOf(
-      9,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    )
-
-  public const val POINT_SIZE_: Int = X25519.POINT_SIZE
 
   public fun scalarMult(input: ByteArray, r: ByteArray): ByteArray {
     val out = ByteArray(input.size)
 
     X25519.scalarMult(input, 0, r, 0, out, 0)
+
+    return out
+  }
+
+  public fun scalarMultBase(input: ByteArray): ByteArray {
+    val out = ByteArray(input.size)
+
+    X25519.scalarMultBase(input, 0, out, 0)
 
     return out
   }

--- a/src/kotlin/kage/crypto/x25519/X25519Recipient.kt
+++ b/src/kotlin/kage/crypto/x25519/X25519Recipient.kt
@@ -6,10 +6,15 @@
 package kage.crypto.x25519
 
 import at.favre.lib.crypto.HKDF
+import com.github.michaelbull.result.getOrThrow
+import com.github.michaelbull.result.mapError
 import java.security.SecureRandom
 import kage.Recipient
 import kage.crypto.stream.ChaCha20Poly1305
+import kage.errors.InvalidRecipientException
+import kage.format.AgeKeyFile.Companion.AGE_PUBLIC_KEY_PREFIX
 import kage.format.AgeStanza
+import kage.format.Bech32
 import kage.utils.encodeBase64
 
 public class X25519Recipient(private val publicKey: ByteArray) : Recipient {
@@ -18,7 +23,7 @@ public class X25519Recipient(private val publicKey: ByteArray) : Recipient {
     val ephemeralSecret = ByteArray(EPHEMERAL_SECRET_LEN)
     SecureRandom().nextBytes(ephemeralSecret)
 
-    val ephemeralShare = X25519.scalarMult(ephemeralSecret, X25519.BASEPOINT)
+    val ephemeralShare = X25519.scalarMultBase(ephemeralSecret)
 
     val salt = ephemeralShare.plus(publicKey)
 
@@ -36,11 +41,28 @@ public class X25519Recipient(private val publicKey: ByteArray) : Recipient {
     return listOf(stanza)
   }
 
+  public fun encodeToString(): String = Bech32.encode(AGE_PUBLIC_KEY_PREFIX, publicKey).getOrThrow()
+
   internal companion object {
     const val X25519_STANZA_TYPE = "X25519"
     const val X25519_INFO = "age-encryption.org/v1/X25519"
     const val KEY_LENGTH = 32 // bytes
     const val MAC_KEY_LENGTH = 32 // bytes
     const val EPHEMERAL_SECRET_LEN = 32 // bytes
+
+    fun decode(string: String): X25519Recipient {
+      val (hrp, key) =
+        Bech32.decode(string)
+          .mapError { InvalidRecipientException("Invalid public key", it) }
+          .getOrThrow()
+
+      if (key.size != KEY_LENGTH)
+        throw InvalidRecipientException("Invalid key size for age public key (${key.size})")
+
+      if (hrp != AGE_PUBLIC_KEY_PREFIX)
+        throw InvalidRecipientException("Invalid human readable part for age public key ($hrp)")
+
+      return X25519Recipient(key)
+    }
   }
 }

--- a/src/kotlin/kage/errors/Bech32Exception.kt
+++ b/src/kotlin/kage/errors/Bech32Exception.kt
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2021 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.errors
+
+/** Thrown when encoding or decoding Bech32 */
+public class Bech32Exception(
+  message: String? = null,
+  cause: Throwable? = null,
+) : Exception(message, cause)

--- a/src/kotlin/kage/errors/CryptoException.kt
+++ b/src/kotlin/kage/errors/CryptoException.kt
@@ -58,8 +58,8 @@ public class IncorrectCipherTextSizeException(
 /**
  * Raised when an identity is not suitable to decrypt a specific recipient block.
  *
- * This is not a fatal exception, kage code should catch this exception and try a different identiy,
- * or fail if other identity does not exist
+ * This is not a fatal exception, kage code should catch this exception and try a different
+ * identity, or fail if other identity does not exist
  */
 public class IncorrectIdentityException(
   cause: Throwable? = null,

--- a/src/kotlin/kage/errors/ParseException.kt
+++ b/src/kotlin/kage/errors/ParseException.kt
@@ -41,7 +41,10 @@ public class InvalidHMACException(
   cause: Throwable? = null,
 ) : ParseException(message, cause)
 
-/** Raised when the [kage.format.AgeKey.privateKey] is empty when parsing a [kage.format.AgeKey]. */
+/**
+ * Raised when the [kage.format.AgeKeyFile.privateKey] is empty when parsing a
+ * [kage.format.AgeKeyFile].
+ */
 public class InvalidAgeKeyException(
   message: String? = null,
   cause: Throwable? = null,

--- a/src/kotlin/kage/format/Bech32.kt
+++ b/src/kotlin/kage/format/Bech32.kt
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2021 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.format
+
+import com.github.michaelbull.result.*
+import kage.errors.Bech32Exception
+
+/**
+ * age.go uses a modified implementation of bech32, so we translate the code from age.go into kotlin
+ * here
+ */
+internal object Bech32 {
+  private const val charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+  private val generator =
+    intArrayOf(0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3).map { it.toUInt() }
+
+  private fun polymod(values: ByteArray): UInt {
+    var chk = 1u
+    for (v in values) {
+      val top = chk shr 25
+      chk = (chk and 33554431u) shl 5
+      chk = chk xor v.toByteUInt()
+      for (i in 0 until 5) {
+        val bit = top shr i and 1u
+        if (bit == 1u) {
+          chk = chk xor generator[i]
+        }
+      }
+    }
+    return chk
+  }
+
+  private fun hrpExpand(hrp: String): ByteArray {
+    val h = hrp.lowercase().toByteArray()
+    val ret = mutableListOf<Byte>()
+
+    for (c in h) {
+      ret.add((c.toByteUInt() shr 5).toByte())
+    }
+
+    ret.add(0)
+
+    for (c in h) {
+      ret.add((c.toByteUInt() and 31u).toByte())
+    }
+
+    return ret.toByteArray()
+  }
+
+  private fun verifyChecksum(hrp: String, data: ByteArray): Boolean =
+    polymod(hrpExpand(hrp).plus(data)) == 1u
+
+  private fun createChecksum(hrp: String, data: ByteArray): ByteArray {
+    val values = hrpExpand(hrp).plus(data).plus(byteArrayOf(0, 0, 0, 0, 0, 0))
+    val mod = polymod(values) xor 1u
+    val ret = ByteArray(6)
+    for (p in ret.indices) {
+      val shift = 5 * (5 - p)
+      ret[p] = ((mod shr shift) and 31u).toByte()
+    }
+    return ret
+  }
+
+  private fun convertBits(
+    data: ByteArray,
+    frombits: Byte,
+    tobits: Byte,
+    pad: Boolean
+  ): Bech32Result<ByteArray> {
+    val ret = mutableListOf<Byte>()
+    var acc = 0u
+    var bits = 0u.toByte()
+    val maxv = ((1 shl tobits.toByteInt()) - 1).toByte()
+    for ((idx, value) in data.withIndex()) {
+      if (value.toByteUInt() shr frombits.toByteInt() != 0u) {
+        return Err(Bech32Exception("invalid data range data[$idx]=$value (frombits=$frombits)"))
+      }
+      acc = acc shl frombits.toByteInt() or value.toByteUInt()
+      bits = bits.plus(frombits).toByte()
+      while (bits >= tobits) {
+        bits = bits.minus(tobits).toByte()
+        ret.add((acc shr bits.toByteInt() and maxv.toByteUInt()).toByte())
+      }
+    }
+    if (pad) {
+      if (bits > 0) {
+        ret.add((acc shl (tobits - bits) and maxv.toByteUInt()).toByte())
+      }
+    } else if (bits >= frombits) {
+      return Err(Bech32Exception("illegal zero padding"))
+    } else if (acc shl (tobits - bits) and maxv.toByteUInt() != 0u) {
+      return Err(Bech32Exception("non-zero padding"))
+    }
+
+    return Ok(ret.toByteArray())
+  }
+
+  //
+  // Encode encodes the HRP and a bytes slice to Bech32. If the HRP is uppercase,
+  // the output will be uppercase.
+  fun encode(hrp: String, data: ByteArray): Bech32Result<String> {
+    val values =
+      when (val maybeValues = convertBits(data, 8, 5, true)) {
+        is Err -> return maybeValues
+        is Ok -> maybeValues.value
+      }
+
+    if (hrp.length + values.size + 7 > 90) {
+      return Err(Bech32Exception("too long: hrp length=${hrp.length}, data length=${values.size}"))
+    }
+    if (hrp.isEmpty()) {
+      return Err(Bech32Exception("invalid HRP: $hrp"))
+    }
+    for ((p, c) in hrp.withIndex()) {
+      if ((c.code < 33) || (c.code > 126)) {
+        return Err(Bech32Exception("invalid HRP character: hrp[$p]=$c"))
+      }
+    }
+    if (hrp.uppercase() != hrp && hrp.lowercase() != hrp) {
+      return Err(Bech32Exception("mixed case HRP: $hrp"))
+    }
+    val lower = hrp.lowercase() == hrp
+    val hrp = hrp.lowercase()
+    val ret = StringBuilder()
+    ret.append(hrp)
+    ret.append("1")
+    for (p in values) {
+      ret.append(charset[p.toByteInt()])
+    }
+    for (p in createChecksum(hrp, values)) {
+      ret.append(charset[p.toByteInt()])
+    }
+    if (lower) {
+      return Ok(ret.toString())
+    }
+    return Ok(ret.toString().uppercase())
+  }
+
+  // Decode decodes a Bech32 string. If the string is uppercase, the HRP will be uppercase.
+  fun decode(s: String): Bech32Result<Pair<String, ByteArray>> {
+    if (s.length > 90) {
+      return Err(Bech32Exception("too long: len=${s.length}"))
+    }
+    if (s.lowercase() != s && s.uppercase() != s) {
+      return Err(Bech32Exception("mixed case"))
+    }
+    val pos = s.lastIndexOf("1")
+    if (pos < 1 || pos + 7 > s.length) {
+      return Err(Bech32Exception("separator '1' invalid at position pos=$pos, len=${s.length}"))
+    }
+    val hrp = s.slice(0 until pos)
+    for ((p, c) in hrp.withIndex()) {
+      if (c.code < 33 || c.code > 126) {
+        return Err(Bech32Exception("Invalid character human-readable part: s[$p]=$c"))
+      }
+    }
+    val sl = s.lowercase()
+    val data = mutableListOf<Byte>()
+    for ((p, c) in sl.slice(pos + 1 until sl.length).withIndex()) {
+      val d = charset.indexOf(c)
+      if (d == -1) {
+        return Err(Bech32Exception("invalid character data part: s[$p]=$c"))
+      }
+      data.add(d.toByte())
+    }
+    val dataArray = data.toByteArray()
+    if (!verifyChecksum(hrp, dataArray)) {
+      return Err(Bech32Exception("invalid checksum"))
+    }
+
+    val convertedBits = convertBits(dataArray.sliceArray(0 until data.size - 6), 5, 8, false)
+
+    return convertedBits.map { Pair(hrp, it) }
+  }
+}
+
+public typealias Bech32Result<T> = Result<T, Bech32Exception>
+
+internal fun Byte.toByteUInt(): UInt = this.toUInt() and 255u
+
+internal fun Byte.toByteInt(): Int = this.toInt() and 0xff

--- a/src/test/kotlin/kage/crypto/x25519/X25519RecipientTest.kt
+++ b/src/test/kotlin/kage/crypto/x25519/X25519RecipientTest.kt
@@ -21,7 +21,7 @@ class X25519RecipientTest {
   fun testWrapUnwrap() {
     val privateKey = ByteArray(32)
     SecureRandom().nextBytes(privateKey)
-    val publicKey = X25519.scalarMult(privateKey, X25519.BASEPOINT)
+    val publicKey = X25519.scalarMultBase(privateKey)
 
     val recipient = X25519Recipient(publicKey)
 

--- a/src/test/kotlin/kage/format/AgeKeyFileTest.kt
+++ b/src/test/kotlin/kage/format/AgeKeyFileTest.kt
@@ -5,12 +5,15 @@
  */
 package kage.format
 
+import java.io.ByteArrayOutputStream
+import kage.crypto.x25519.X25519Identity
+import kage.crypto.x25519.X25519Recipient
 import kage.errors.InvalidAgeKeyException
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import org.junit.Test
 
-class AgeKeyTest {
+class AgeKeyFileTest {
 
   @Test
   fun testAgeKeyFile() {
@@ -22,16 +25,16 @@ class AgeKeyTest {
     """.trimIndent()
 
     val reader = keyString.reader().buffered()
-    val key = AgeKey.parse(reader)
+    val key = AgeKeyFile.parse(reader)
 
     assertEquals("2006-01-02T15:04:05Z07:00", key.created)
     assertEquals(
       "age1mrmfnwhtlprn4jquex0ukmwcm7y2nxlphuzgsgv8ew2k9mewy3rs8u7su5",
-      key.publicKey.decodeToString()
+      key.publicKey?.encodeToString()
     )
     assertEquals(
       "AGE-SECRET-KEY-1EKYFFCK627939WTZMTT4ZRS2PM3U2K7PZ3MVGEL2M76W3PYJMSHQMTT6SS",
-      key.privateKey.decodeToString()
+      key.privateKey.encodeToString()
     )
   }
 
@@ -43,11 +46,11 @@ class AgeKeyTest {
     """.trimIndent()
 
     val reader = keyString.reader().buffered()
-    val key = AgeKey.parse(reader)
+    val key = AgeKeyFile.parse(reader)
 
     assertEquals(
       "AGE-SECRET-KEY-1EKYFFCK627939WTZMTT4ZRS2PM3U2K7PZ3MVGEL2M76W3PYJMSHQMTT6SS",
-      key.privateKey.decodeToString()
+      key.privateKey.encodeToString()
     )
   }
 
@@ -62,7 +65,7 @@ class AgeKeyTest {
 
     val reader = keyString.reader().buffered()
 
-    assertFailsWith<InvalidAgeKeyException> { AgeKey.parse(reader) }
+    assertFailsWith<InvalidAgeKeyException> { AgeKeyFile.parse(reader) }
   }
 
   @Test
@@ -76,12 +79,12 @@ class AgeKeyTest {
     """.trimIndent()
 
     val reader = keyString.reader().buffered()
-    val key = AgeKey.parse(reader)
+    val key = AgeKeyFile.parse(reader)
 
     assertEquals("2006-01-02T15:04:05Z07:00", key.created)
     assertEquals(
       "AGE-SECRET-KEY-1EKYFFCK627939WTZMTT4ZRS2PM3U2K7PZ3MVGEL2M76W3PYJMSHQMTT6SS",
-      key.privateKey.decodeToString()
+      key.privateKey.encodeToString()
     )
   }
 
@@ -95,7 +98,7 @@ class AgeKeyTest {
 
     val reader = keyString.reader().buffered()
 
-    assertFailsWith<InvalidAgeKeyException> { AgeKey.parse(reader) }
+    assertFailsWith<InvalidAgeKeyException> { AgeKeyFile.parse(reader) }
   }
 
   @Test
@@ -108,16 +111,44 @@ class AgeKeyTest {
     """.trimIndent()
 
     val reader = keyString.reader().buffered()
-    val key = AgeKey.parse(reader)
+    val key = AgeKeyFile.parse(reader)
 
     assertEquals("2006-01-02T15:04:05Z07:00", key.created)
     assertEquals(
       "age1mrmfnwhtlprn4jquex0ukmwcm7y2nxlphuzgsgv8ew2k9mewy3rs8u7su5",
-      key.publicKey.decodeToString()
+      key.publicKey?.encodeToString()
     )
     assertEquals(
       "AGE-SECRET-KEY-1EKYFFCK627939WTZMTT4ZRS2PM3U2K7PZ3MVGEL2M76W3PYJMSHQMTT6SS",
-      key.privateKey.decodeToString()
+      key.privateKey.encodeToString()
     )
+  }
+
+  @Test
+  fun testWrite() {
+    val keyString =
+      """
+        # created: 2006-01-02T15:04:05Z07:00
+        # public key: age1mrmfnwhtlprn4jquex0ukmwcm7y2nxlphuzgsgv8ew2k9mewy3rs8u7su5
+        AGE-SECRET-KEY-1EKYFFCK627939WTZMTT4ZRS2PM3U2K7PZ3MVGEL2M76W3PYJMSHQMTT6SS
+        
+        """.trimIndent()
+
+    val publicKey =
+      X25519Recipient.decode("age1mrmfnwhtlprn4jquex0ukmwcm7y2nxlphuzgsgv8ew2k9mewy3rs8u7su5")
+
+    val privateKey =
+      X25519Identity.decode(
+        "AGE-SECRET-KEY-1EKYFFCK627939WTZMTT4ZRS2PM3U2K7PZ3MVGEL2M76W3PYJMSHQMTT6SS"
+      )
+
+    val ageKeyFile = AgeKeyFile("2006-01-02T15:04:05Z07:00", publicKey, privateKey)
+
+    val out = ByteArrayOutputStream()
+    val writer = out.bufferedWriter()
+    AgeKeyFile.write(writer, ageKeyFile)
+    writer.flush()
+
+    assertEquals(keyString, out.toString())
   }
 }

--- a/src/test/kotlin/kage/format/Bech32Test.kt
+++ b/src/test/kotlin/kage/format/Bech32Test.kt
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2021 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.kage.format
+
+import com.github.michaelbull.result.getOrThrow
+import com.github.michaelbull.result.unwrapError
+import kage.errors.Bech32Exception
+import kage.format.Bech32
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import org.bouncycastle.util.encoders.Hex
+import org.junit.Test
+
+class Bech32Test {
+
+  @Test
+  fun testEncode() {
+    val s = "age1z2fw2ks7jp7ak3tjven6kxd53m7lxgmn9j7nrt0gfmewcr4sav9sp2n34j"
+
+    val h = "1292e55a1e907ddb45726667ab19b48efdf323732cbd31ade84ef2ec0eb0eb0b"
+
+    val dh = Hex.decode(h)
+
+    val encoded = Bech32.encode("age", dh).getOrThrow()
+
+    assertEquals(s, encoded)
+  }
+
+  @Test
+  fun testDecode() {
+    val s = "age1z2fw2ks7jp7ak3tjven6kxd53m7lxgmn9j7nrt0gfmewcr4sav9sp2n34j"
+
+    val (hrp, data) = Bech32.decode(s).getOrThrow()
+
+    assertEquals("age", hrp)
+    assertEquals(
+      "1292e55a1e907ddb45726667ab19b48efdf323732cbd31ade84ef2ec0eb0eb0b",
+      Hex.toHexString(data)
+    )
+  }
+
+  // Test used by age.go
+  @Test
+  fun testBech32() {
+    data class T(val string: String, val valid: Boolean)
+
+    val tests =
+      listOf(
+        T("A12UEL5L", true),
+        T("a12uel5l", true),
+        T(
+          "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
+          true
+        ),
+        T("abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw", true),
+        T(
+          "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
+          true
+        ),
+        T("split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", true),
+
+        // invalid checksum
+        T("split1checkupstagehandshakeupstreamerranterredcaperred2y9e2w", false),
+        // invalid character (space) in hrp
+        T("s lit1checkupstagehandshakeupstreamerranterredcaperredp8hs2p", false),
+        T("split1cheo2y9e2w", false), // invalid character (o) in data part
+        T("split1a2y9w", false), // too short data part
+        T("1checkupstagehandshakeupstreamerranterredcaperred2y9e3w", false), // empty hrp
+        // invalid character (DEL) in hrp
+        T(
+          "spl" + (127).toChar() + "t1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
+          false
+        ),
+        // too long
+        T(
+          "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
+          false
+        ),
+
+        // BIP 173 invalid vectors.
+        T(
+          "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
+          false
+        ),
+        T("pzry9x0s0muk", false),
+        T("1pzry9x0s0muk", false),
+        T("x1b4n0q5v", false),
+        T("li1dgmt3", false),
+        T("de1lg7wt\\xff", false),
+        T("A1G7SGD8", false),
+        T("10a06t8", false),
+        T("1qzzfhee", false),
+      )
+
+    for (test in tests) {
+      val str = test.string
+
+      if (!test.valid) {
+        val err = Bech32.decode(str)
+        assertIs<Bech32Exception>(err.unwrapError())
+
+        continue
+      }
+
+      // Valid string decoding should result in no error.
+      val (hrp, decoded) = Bech32.decode(str).getOrThrow()
+
+      // Check that it encodes to the same string.
+      val encoded = Bech32.encode(hrp, decoded).getOrThrow()
+
+      assertEquals(str, encoded)
+
+      // Flip a bit in the string and make sure it is caught.
+      val pos = str.lastIndexOf("1")
+      val flipped =
+        str.slice(0 until pos + 1) +
+          (str[pos + 1].code xor 1).toString() +
+          str.slice(pos + 2 until str.length)
+
+      val res = Bech32.decode(flipped)
+
+      assertIs<Bech32Exception>(res.unwrapError())
+    }
+  }
+}


### PR DESCRIPTION
In AgeKey, which is now AgeKeyFile and represents age identity files.

Add test for `AgeKeyFile.parse`

Parse public and private keys using bech32. Age.go uses a modified implementation of Bech32. I tried some java and kotlin implementations and they would not decode payloads encoded by age.go into the same original values, so I took the age.go implementation and ported it to kotlin here.

Use `kotlin-result` to handle errors when encoding/decoding bech32.

Instead of using the names `AgePublicKey`, and `AgePrivateKey`, I think it makes sense to use `X25519Recipient` and `X25519Identity` respectively, as this is what age.go, does. So I renamed `AgeKey` to `AgeKeyFile`, which holds a `X25519Recipient` and a `X25519Identity`, and represents a file that can be written and read, similar to `AgeFile`.

I think this crosses off all the remaining items in #15 except "Implement convenience methods for library users".