### PR TITLE
Fix building on pushes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.head_ref }}
-  cancel-in-progress: true
-
 name: Run tests
 jobs:
   check:


### PR DESCRIPTION
Renovate has been raising PRs for weeks because all the branch builds failed, this will remedy it.
