### PR TITLE
Generate and execute tests from CCTV vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,36 @@ gradle-app.setting
 # End of https://www.toptal.com/developers/gitignore/api/kotlin,gradle
 
 .idea/
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -18,6 +18,7 @@ import kage.errors.IncorrectHMACException
 import kage.errors.InvalidScryptRecipientException
 import kage.errors.NoIdentitiesException
 import kage.errors.NoRecipientsException
+import kage.errors.ScryptIdentityException
 import kage.format.AgeFile
 import kage.format.AgeHeader
 
@@ -126,6 +127,11 @@ public object Age {
     if (identities.isEmpty()) throw NoIdentitiesException("no identities specified")
 
     val exceptions = mutableListOf<Exception>()
+
+    ageFile.header.recipients.forEach { stanza ->
+      if (stanza.type == ScryptRecipient.SCRYPT_STANZA_TYPE && ageFile.header.recipients.size != 1)
+        throw ScryptIdentityException("an scrypt identity must be the only one")
+    }
 
     for (identity in identities) {
       val fileKey =

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -15,6 +15,7 @@ import kage.crypto.scrypt.ScryptRecipient
 import kage.crypto.stream.DecryptInputStream
 import kage.crypto.stream.EncryptOutputStream
 import kage.errors.IncorrectHMACException
+import kage.errors.InvalidHMACHeaderException
 import kage.errors.InvalidScryptRecipientException
 import kage.errors.NoIdentitiesException
 import kage.errors.NoRecipientsException
@@ -25,6 +26,7 @@ import kage.format.AgeHeader
 public object Age {
   internal const val FILE_KEY_SIZE: Int = 16
   private const val STREAM_NONCE_SIZE = 16
+  private const val HMAC_SIZE = 32
 
   @JvmStatic
   public fun encryptStream(
@@ -141,6 +143,10 @@ public object Age {
           exceptions.add(err)
           continue
         }
+
+
+      if (ageFile.header.mac.size != HMAC_SIZE)
+        throw InvalidHMACHeaderException("invalid header mac")
 
       val calculatedMac = Primitives.headerMAC(fileKey, ageFile.header)
 

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -144,7 +144,6 @@ public object Age {
           continue
         }
 
-
       if (ageFile.header.mac.size != HMAC_SIZE)
         throw InvalidHMACHeaderException("invalid header mac")
 

--- a/src/kotlin/kage/Identity.kt
+++ b/src/kotlin/kage/Identity.kt
@@ -5,7 +5,6 @@
  */
 package kage
 
-import kage.errors.IncorrectIdentityException
 import kage.format.AgeStanza
 
 /**

--- a/src/kotlin/kage/Identity.kt
+++ b/src/kotlin/kage/Identity.kt
@@ -22,16 +22,16 @@ public interface Identity {
 }
 
 internal fun multiUnwrap(unwrapFn: (AgeStanza) -> ByteArray, stanzas: List<AgeStanza>): ByteArray {
-  val lastError = IncorrectIdentityException()
+  val exceptions = mutableListOf<Exception>()
 
   stanzas.forEach { stanza ->
     try {
       return unwrapFn(stanza)
-    } catch (err: IncorrectIdentityException) {
+    } catch (err: Exception) {
       // will try next stanza
-      lastError.addSuppressed(err)
+      exceptions.add(err)
     }
   }
 
-  throw lastError
+  throw exceptions.reduce { acc, exception -> acc.apply { addSuppressed(exception) } }
 }

--- a/src/kotlin/kage/crypto/scrypt/ScryptIdentity.kt
+++ b/src/kotlin/kage/crypto/scrypt/ScryptIdentity.kt
@@ -26,11 +26,6 @@ public class ScryptIdentity(
   }
 
   override fun unwrap(stanzas: List<AgeStanza>): ByteArray {
-    stanzas.forEach { stanza ->
-      if (stanza.type == ScryptRecipient.SCRYPT_STANZA_TYPE && stanzas.size != 1)
-        throw ScryptIdentityException("an scrypt identity must be the only one")
-    }
-
     return multiUnwrap(::unwrapSingle, stanzas)
   }
 

--- a/src/kotlin/kage/crypto/scrypt/ScryptIdentity.kt
+++ b/src/kotlin/kage/crypto/scrypt/ScryptIdentity.kt
@@ -62,9 +62,12 @@ public class ScryptIdentity(
 
     val fullSalt = ScryptRecipient.SCRYPT_SALT_LABEL.toByteArray().plus(salt)
 
-    val wrappingKey = SCrypt.generate(password, fullSalt, 1 shl workFactor, 8, 1, KEY_LENGTH)
-
-    return ChaCha20Poly1305.aeadDecrypt(wrappingKey, stanza.body, Age.FILE_KEY_SIZE)
+    try {
+      val wrappingKey = SCrypt.generate(password, fullSalt, 1 shl workFactor, 8, 1, KEY_LENGTH)
+      return ChaCha20Poly1305.aeadDecrypt(wrappingKey, stanza.body, Age.FILE_KEY_SIZE)
+    } catch (err: Exception) {
+      throw ScryptIdentityException(null, err)
+    }
   }
 
   internal companion object {

--- a/src/kotlin/kage/crypto/stream/DecryptInputStream.kt
+++ b/src/kotlin/kage/crypto/stream/DecryptInputStream.kt
@@ -89,14 +89,19 @@ internal class DecryptInputStream(private val key: ByteArray, private val input:
       unreadOffset = 0
     } catch (err: Exception) {
       if (last) // If we already tried to decode as last chunk, just throw the error
-       throw err
+       throw StreamException("error occurred while decrypting stream", err)
 
       // Try to decode as a final chunk
       last = true
       setLastChunkFlag(this.nonce)
 
-      unreadSize = ChaCha20Poly1305.decrypt(key, nonce, buf, 0, bufSize, unread, 0)
-      unreadOffset = 0
+      try {
+        unreadSize = ChaCha20Poly1305.decrypt(key, nonce, buf, 0, bufSize, unread, 0)
+        unreadOffset = 0
+      } catch (err: Exception) {
+        throw StreamException("error occurred while decrypting stream", err)
+      }
+
     }
 
     incNonce(this.nonce)

--- a/src/kotlin/kage/crypto/stream/DecryptInputStream.kt
+++ b/src/kotlin/kage/crypto/stream/DecryptInputStream.kt
@@ -101,7 +101,6 @@ internal class DecryptInputStream(private val key: ByteArray, private val input:
       } catch (err: Exception) {
         throw StreamException("error occurred while decrypting stream", err)
       }
-
     }
 
     incNonce(this.nonce)

--- a/src/kotlin/kage/crypto/x25519/X25519Identity.kt
+++ b/src/kotlin/kage/crypto/x25519/X25519Identity.kt
@@ -13,9 +13,7 @@ import kage.Identity
 import kage.crypto.stream.ChaCha20Poly1305
 import kage.crypto.x25519.X25519Recipient.Companion.MAC_KEY_LENGTH
 import kage.crypto.x25519.X25519Recipient.Companion.X25519_INFO
-import kage.errors.IncorrectCipherTextSizeException
 import kage.errors.IncorrectIdentityException
-import kage.errors.InvalidIdentityException
 import kage.errors.X25519IdentityException
 import kage.format.AgeKeyFile
 import kage.format.AgeStanza

--- a/src/kotlin/kage/errors/CryptoException.kt
+++ b/src/kotlin/kage/errors/CryptoException.kt
@@ -79,3 +79,10 @@ public class StreamException(
   message: String? = null,
   cause: Throwable? = null,
 ) : CryptoException(message, cause)
+
+/** Raised when the Base64 string is not canonical according to RFC 4648 section 3.5 */
+public class InvalidBase64StringException(
+  message: String? = null,
+  cause: Throwable? = null,
+) : CryptoException(message, cause)
+

--- a/src/kotlin/kage/errors/CryptoException.kt
+++ b/src/kotlin/kage/errors/CryptoException.kt
@@ -27,7 +27,6 @@ public class InvalidScryptRecipientException(
   cause: Throwable? = null,
 ) : CryptoException(message, cause)
 
-
 /** Raised when an incompatible stanza is provided to [kage.Identity.unwrap] */
 public sealed class InvalidIdentityException(
   message: String? = null,
@@ -87,10 +86,8 @@ public class InvalidBase64StringException(
   cause: Throwable? = null,
 ) : CryptoException(message, cause)
 
-
 /** Raised when the mac is incorrect */
 public class IncorrectHMACException(
   message: String? = null,
   cause: Throwable? = null,
 ) : CryptoException(message, cause)
-

--- a/src/kotlin/kage/errors/CryptoException.kt
+++ b/src/kotlin/kage/errors/CryptoException.kt
@@ -92,7 +92,7 @@ public class IncorrectHMACException(
   cause: Throwable? = null,
 ) : CryptoException(message, cause)
 
-/** Raised when the mac is invalid (truncated or the wrong size) **/
+/** Raised when the mac is invalid (truncated or the wrong size) */
 public class InvalidHMACHeaderException(
   message: String? = null,
   cause: Throwable? = null,

--- a/src/kotlin/kage/errors/CryptoException.kt
+++ b/src/kotlin/kage/errors/CryptoException.kt
@@ -27,17 +27,24 @@ public class InvalidScryptRecipientException(
   cause: Throwable? = null,
 ) : CryptoException(message, cause)
 
+
+/** Raised when an incompatible stanza is provided to [kage.Identity.unwrap] */
+public sealed class InvalidIdentityException(
+  message: String? = null,
+  cause: Throwable? = null,
+) : CryptoException(message, cause)
+
 /** Raised when an error occurs when unwrapping an scrypt stanza from an [kage.Identity]. */
 public class ScryptIdentityException(
   message: String? = null,
   cause: Throwable? = null,
-) : CryptoException(message, cause)
+) : InvalidIdentityException(message, cause)
 
 /** Raised when an error occurs when unwrapping a X25519 stanza from an [kage.Identity]. */
 public class X25519IdentityException(
   message: String? = null,
   cause: Throwable? = null,
-) : CryptoException(message, cause)
+) : InvalidIdentityException(message, cause)
 
 /**
  * Raised when an error occurs while calculating the X25519 shared secret. If the X25519 share is a
@@ -46,19 +53,13 @@ public class X25519IdentityException(
 public class X25519LowOrderPointException(
   message: String? = null,
   cause: Throwable? = null,
-) : CryptoException(message, cause)
-
-/** Raised when an incompatible stanza is provided to [kage.Identity.unwrap] */
-public class InvalidIdentityException(
-  message: String? = null,
-  cause: Throwable? = null,
-) : CryptoException(message, cause)
+) : InvalidIdentityException(message, cause)
 
 /** Raised when there are no [kage.Identity]s when decrypting a ciphertext */
 public class NoIdentitiesException(
   message: String? = null,
   cause: Throwable? = null,
-) : CryptoException(message, cause)
+) : InvalidIdentityException(message, cause)
 
 public class IncorrectCipherTextSizeException(
   cause: Throwable? = null,
@@ -82,6 +83,13 @@ public class StreamException(
 
 /** Raised when the Base64 string is not canonical according to RFC 4648 section 3.5 */
 public class InvalidBase64StringException(
+  message: String? = null,
+  cause: Throwable? = null,
+) : CryptoException(message, cause)
+
+
+/** Raised when the mac is incorrect */
+public class IncorrectHMACException(
   message: String? = null,
   cause: Throwable? = null,
 ) : CryptoException(message, cause)

--- a/src/kotlin/kage/errors/CryptoException.kt
+++ b/src/kotlin/kage/errors/CryptoException.kt
@@ -91,3 +91,9 @@ public class IncorrectHMACException(
   message: String? = null,
   cause: Throwable? = null,
 ) : CryptoException(message, cause)
+
+/** Raised when the mac is invalid (truncated or the wrong size) **/
+public class InvalidHMACHeaderException(
+  message: String? = null,
+  cause: Throwable? = null,
+) : CryptoException(message, cause)

--- a/src/kotlin/kage/errors/ParseException.kt
+++ b/src/kotlin/kage/errors/ParseException.kt
@@ -49,9 +49,3 @@ public class InvalidAgeKeyException(
   message: String? = null,
   cause: Throwable? = null,
 ) : ParseException(message, cause)
-
-/** Raised when the Base64 string is not canonical according to RFC 4648 section 3.5 */
-public class InvalidBase64StringException(
-  message: String? = null,
-  cause: Throwable? = null,
-) : ParseException(message, cause)

--- a/src/kotlin/kage/format/AgeStanza.kt
+++ b/src/kotlin/kage/format/AgeStanza.kt
@@ -7,9 +7,9 @@ package kage.format
 
 import com.github.michaelbull.result.getOrThrow
 import com.github.michaelbull.result.mapError
+import com.github.michaelbull.result.runCatching
 import java.io.BufferedInputStream
 import java.io.BufferedWriter
-import java.util.Base64
 import kage.errors.InvalidArbitraryStringException
 import kage.errors.InvalidRecipientException
 import kage.format.AgeFile.Companion.BYTES_PER_LINE
@@ -23,7 +23,6 @@ import kage.utils.encodeBase64
 import kage.utils.readLine
 import kage.utils.writeNewLine
 import kage.utils.writeSpace
-import com.github.michaelbull.result.runCatching
 
 public class AgeStanza(
   public val type: String,
@@ -168,7 +167,10 @@ public class AgeStanza(
               "Line is null, did you forget an extra newline after a full length body chunk?"
             )
 
-        val bytes = runCatching { line.decodeBase64() }.mapError { e -> InvalidRecipientException("error occurred while decoding", e) }.getOrThrow()
+        val bytes =
+          runCatching { line.decodeBase64() }
+            .mapError { e -> InvalidRecipientException("error occurred while decoding", e) }
+            .getOrThrow()
         if (bytes.size > BYTES_PER_LINE)
           throw InvalidRecipientException("Body line is too long: $line")
 

--- a/src/kotlin/kage/format/AgeStanza.kt
+++ b/src/kotlin/kage/format/AgeStanza.kt
@@ -5,6 +5,8 @@
  */
 package kage.format
 
+import com.github.michaelbull.result.getOrThrow
+import com.github.michaelbull.result.mapError
 import java.io.BufferedInputStream
 import java.io.BufferedWriter
 import java.util.Base64
@@ -16,10 +18,12 @@ import kage.format.AgeFile.Companion.FOOTER_PREFIX
 import kage.format.AgeFile.Companion.RECIPIENT_PREFIX
 import kage.format.ParseUtils.isValidArbitraryString
 import kage.format.ParseUtils.splitArgs
+import kage.utils.decodeBase64
 import kage.utils.encodeBase64
 import kage.utils.readLine
 import kage.utils.writeNewLine
 import kage.utils.writeSpace
+import com.github.michaelbull.result.runCatching
 
 public class AgeStanza(
   public val type: String,
@@ -164,7 +168,7 @@ public class AgeStanza(
               "Line is null, did you forget an extra newline after a full length body chunk?"
             )
 
-        val bytes = Base64.getDecoder().decode(line)
+        val bytes = runCatching { line.decodeBase64() }.mapError { e -> InvalidRecipientException("error occurred while decoding", e) }.getOrThrow()
         if (bytes.size > BYTES_PER_LINE)
           throw InvalidRecipientException("Body line is too long: $line")
 

--- a/src/test/kotlin/kage/UpstreamTestSuite.kt
+++ b/src/test/kotlin/kage/UpstreamTestSuite.kt
@@ -67,6 +67,9 @@ class UpstreamTestSuite {
             val payloadHash = PayloadHash(md.digest(baos.toByteArray()))
             assertThat(payloadHash.bytes).isEqualTo(expectedHash.bytes)
           }
+          if (expect != Success) {
+            fail("expected $expect, got success")
+          }
         }
       }
   }

--- a/src/test/kotlin/kage/UpstreamTestSuite.kt
+++ b/src/test/kotlin/kage/UpstreamTestSuite.kt
@@ -5,20 +5,73 @@
  */
 package kage
 
+import com.github.michaelbull.result.getError
+import com.github.michaelbull.result.runCatching
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayOutputStream
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.security.MessageDigest
+import kage.errors.IncorrectIdentityException
+import kage.errors.InvalidHMACException
 import kage.kage.test.utils.TestSuite
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
+import kage.test.utils.Expect.ArmorFailure
+import kage.test.utils.Expect.HMACFailure
+import kage.test.utils.Expect.HeaderFailure
+import kage.test.utils.Expect.NoMatch
+import kage.test.utils.Expect.PayloadFailure
+import kage.test.utils.Expect.Success
+import kage.test.utils.PayloadHash
+import kotlin.io.path.name
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.fail
 
 class UpstreamTestSuite {
   private val testFixtureRoot = Paths.get("src", "test", "resources", "CCTV", "age", "testdata")
 
-  @Test
-  fun test() {
-    Files.newDirectoryStream(testFixtureRoot).forEach { path ->
-      val contents = path.toFile().readBytes()
-      assertDoesNotThrow("failed to parse ${path.fileName}") { TestSuite.parse(contents) }
-    }
+  @TestFactory
+  fun generateTests(): List<DynamicTest> {
+    return Files.newDirectoryStream(testFixtureRoot)
+      // TODO: enable armor tests
+      .filter { path -> !path.name.contains("armor") }
+      .map { path ->
+        val contents = path.toFile().readBytes()
+        DynamicTest.dynamicTest(path.name) {
+          val suite = TestSuite.parse(contents)
+          val expect = suite.expect
+
+          val baos = ByteArrayOutputStream()
+          val result = runCatching {
+            Age.decryptStream(suite.identities, suite.testContent.inputStream(), baos)
+          }
+
+          val error = result.getError()
+          if (error != null && error is InvalidHMACException) {
+            if (expect != HMACFailure) {
+              fail("expected $expect, got HMAC error")
+            }
+          } else if (error != null && hasCause<IncorrectIdentityException>(error)) {
+            if (expect == NoMatch) {
+              return@dynamicTest
+            }
+          } else if (error != null) {
+            if (expect == HeaderFailure) {
+              return@dynamicTest
+            }
+          } else if (expect != Success && expect != PayloadFailure && expect != ArmorFailure) {
+            fail("expected $expect, got success")
+          }
+          suite.payloadHash?.let { expectedHash ->
+            val md = MessageDigest.getInstance("SHA-256")
+            val payloadHash = PayloadHash(md.digest(baos.toByteArray()))
+            assertThat(payloadHash.bytes).isEqualTo(expectedHash.bytes)
+          }
+        }
+      }
+  }
+
+  private inline fun <reified T : Exception> hasCause(error: Throwable): Boolean {
+    return generateSequence(error) { error.cause }.firstOrNull { e -> e is T } != null
   }
 }

--- a/src/test/kotlin/kage/UpstreamTestSuite.kt
+++ b/src/test/kotlin/kage/UpstreamTestSuite.kt
@@ -12,15 +12,8 @@ import java.io.ByteArrayOutputStream
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.security.MessageDigest
-import kage.errors.IncorrectIdentityException
-import kage.errors.InvalidHMACException
 import kage.kage.test.utils.TestSuite
 import kage.kage.utils.mapToUpstreamExpect
-import kage.test.utils.Expect.ArmorFailure
-import kage.test.utils.Expect.HMACFailure
-import kage.test.utils.Expect.HeaderFailure
-import kage.test.utils.Expect.NoMatch
-import kage.test.utils.Expect.PayloadFailure
 import kage.test.utils.Expect.Success
 import kage.test.utils.PayloadHash
 import kotlin.io.path.name
@@ -59,37 +52,7 @@ class UpstreamTestSuite {
             error.printStackTrace()
             val actual = mapToUpstreamExpect(error)
             assertThat(actual).isEqualTo(expect)
-//            if (expect == actual) return@dynamicTest
-//            else fail("expected $expect, got $actual")
-//            when(expect) {
-//              Success -> fail("expected success, got actual")
-//              HMACFailure -> if (actual == HMACFailure) return@dynamicTest else fail()
-//              HeaderFailure -> TODO()
-//              ArmorFailure -> TODO()
-//              PayloadFailure -> TODO()
-//              NoMatch -> TODO()
-//            }
           }
-
-//          if (error != null && error is InvalidHMACException) {
-//            if (expect != HMACFailure) {
-//              fail("expected $expect, got HMAC error")
-//            }
-//          } else if (error != null && hasCause<IncorrectIdentityException>(error)) {
-//            if (expect == NoMatch) {
-//              return@dynamicTest
-//            }
-//          } else if (error != null) {
-//            if (expect == HeaderFailure) {
-//              return@dynamicTest
-//            }
-//          } else if (expect != Success && expect != PayloadFailure && expect != ArmorFailure) {
-//            fail("expected $expect, got success")
-//          }
-//
-//          if (expect != Success) {
-//            fail("expected $expect, got success")
-//          }
         }
       }
   }

--- a/src/test/kotlin/kage/test/utils/TestSuite.kt
+++ b/src/test/kotlin/kage/test/utils/TestSuite.kt
@@ -17,7 +17,7 @@ private constructor(
   val payloadHash: PayloadHash?,
   val identities: List<Identity>,
   val armored: Boolean,
-  val result: ByteArray,
+  val testContent: ByteArray,
 ) {
   companion object {
     fun parse(contents: ByteArray): TestSuite {

--- a/src/test/kotlin/kage/test/utils/types.kt
+++ b/src/test/kotlin/kage/test/utils/types.kt
@@ -28,7 +28,7 @@ enum class Expect {
   }
 }
 
-class PayloadHash private constructor(val bytes: ByteArray) {
+class PayloadHash(val bytes: ByteArray) {
   companion object {
     fun from(value: String): PayloadHash {
       check(value.length % 2 == 0) { "Must have an even length" }

--- a/src/test/kotlin/kage/utils/Extensions.kt
+++ b/src/test/kotlin/kage/utils/Extensions.kt
@@ -31,10 +31,8 @@ private inline fun <reified T : Exception> hasCause(error: Throwable): Boolean {
 fun mapToUpstreamExpect(error: Throwable): Expect {
   if (error is InvalidIdentityException && hasCause<InvalidCipherTextException>(error))
     return NoMatch
-  if (error is IncorrectHMACException || hasCause<IncorrectHMACException>(error))
-    return HMACFailure
-  if (error is InvalidHMACHeaderException)
-    return HeaderFailure
+  if (error is IncorrectHMACException || hasCause<IncorrectHMACException>(error)) return HMACFailure
+  if (error is InvalidHMACHeaderException) return HeaderFailure
   if (error is IncorrectIdentityException) return NoMatch
   if (error is StreamException) return PayloadFailure
   if (error is ParseException) return HeaderFailure

--- a/src/test/kotlin/kage/utils/Extensions.kt
+++ b/src/test/kotlin/kage/utils/Extensions.kt
@@ -1,27 +1,17 @@
+/**
+ * Copyright 2023 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
 package kage.kage.utils
 
 import kage.errors.CryptoException
-import kage.errors.IncorrectCipherTextSizeException
 import kage.errors.IncorrectHMACException
 import kage.errors.IncorrectIdentityException
-import kage.errors.InvalidAgeKeyException
-import kage.errors.InvalidArbitraryStringException
-import kage.errors.InvalidBase64StringException
-import kage.errors.InvalidFooterException
-import kage.errors.InvalidHMACException
 import kage.errors.InvalidIdentityException
-import kage.errors.InvalidRecipientException
-import kage.errors.InvalidScryptRecipientException
-import kage.errors.InvalidVersionException
-import kage.errors.NoIdentitiesException
-import kage.errors.NoRecipientsException
 import kage.errors.ParseException
-import kage.errors.ScryptIdentityException
 import kage.errors.StreamException
-import kage.errors.X25519IdentityException
-import kage.errors.X25519LowOrderPointException
 import kage.test.utils.Expect
-import kage.test.utils.Expect.HMACFailure
 import kage.test.utils.Expect.HeaderFailure
 import kage.test.utils.Expect.NoMatch
 import kage.test.utils.Expect.PayloadFailure
@@ -29,7 +19,7 @@ import org.bouncycastle.crypto.InvalidCipherTextException
 
 private inline fun <reified T : Exception> hasCause(error: Throwable): Boolean {
   var cause = error.cause
-  while(cause != null) {
+  while (cause != null) {
     if (error.cause is T) return true
     cause = cause.cause
   }
@@ -37,8 +27,10 @@ private inline fun <reified T : Exception> hasCause(error: Throwable): Boolean {
 }
 
 fun mapToUpstreamExpect(error: Throwable): Expect {
-  if (error is InvalidIdentityException && hasCause<InvalidCipherTextException>(error)) return NoMatch
-  if (error is IncorrectHMACException || hasCause<IncorrectHMACException>(error)) return HeaderFailure
+  if (error is InvalidIdentityException && hasCause<InvalidCipherTextException>(error))
+    return NoMatch
+  if (error is IncorrectHMACException || hasCause<IncorrectHMACException>(error))
+    return HeaderFailure
   if (error is IncorrectIdentityException) return NoMatch
   if (error is StreamException) return PayloadFailure
   if (error is ParseException) return HeaderFailure
@@ -47,37 +39,4 @@ fun mapToUpstreamExpect(error: Throwable): Expect {
   // TODO: Handle cases where we are throwing anything other than CryptoException or ParseException
   //  throw IllegalStateException("Only exceptions thrown by kage can be mapped to expect value")
   return HeaderFailure
-
-//  return when (this) {
-//    is CryptoException -> {
-//      when (this) {
-//        is IncorrectCipherTextSizeException -> HeaderFailure
-//        is IncorrectIdentityException -> NoMatch
-//        is InvalidBase64StringException -> HeaderFailure
-//        is InvalidIdentityException -> HeaderFailure
-//        is InvalidScryptRecipientException -> HeaderFailure
-//        is NoIdentitiesException -> HeaderFailure
-//        is NoRecipientsException -> HeaderFailure
-//        is ScryptIdentityException -> if (hasCause<InvalidCipherTextException>(this)) NoMatch else HeaderFailure
-//        is StreamException -> PayloadFailure
-//        is X25519IdentityException -> /*if (hasCause<InvalidCipherTextException>(this)) NoMatch else*/ HeaderFailure
-//        is X25519LowOrderPointException -> HeaderFailure
-//        is IncorrectHMACException -> HMACFailure
-//      }
-//    }
-//
-//    is ParseException -> {
-//      when (this) {
-//        is InvalidAgeKeyException -> Expect.HeaderFailure
-//        is InvalidArbitraryStringException -> Expect.HeaderFailure
-//        is InvalidFooterException -> Expect.HeaderFailure
-//        is InvalidHMACException -> Expect.HeaderFailure
-//        is InvalidRecipientException -> Expect.HeaderFailure
-//        is InvalidVersionException -> Expect.HeaderFailure
-//      }
-//    }
-//
-//    else -> {
-//    }
-//  }
 }

--- a/src/test/kotlin/kage/utils/Extensions.kt
+++ b/src/test/kotlin/kage/utils/Extensions.kt
@@ -1,0 +1,83 @@
+package kage.kage.utils
+
+import kage.errors.CryptoException
+import kage.errors.IncorrectCipherTextSizeException
+import kage.errors.IncorrectHMACException
+import kage.errors.IncorrectIdentityException
+import kage.errors.InvalidAgeKeyException
+import kage.errors.InvalidArbitraryStringException
+import kage.errors.InvalidBase64StringException
+import kage.errors.InvalidFooterException
+import kage.errors.InvalidHMACException
+import kage.errors.InvalidIdentityException
+import kage.errors.InvalidRecipientException
+import kage.errors.InvalidScryptRecipientException
+import kage.errors.InvalidVersionException
+import kage.errors.NoIdentitiesException
+import kage.errors.NoRecipientsException
+import kage.errors.ParseException
+import kage.errors.ScryptIdentityException
+import kage.errors.StreamException
+import kage.errors.X25519IdentityException
+import kage.errors.X25519LowOrderPointException
+import kage.test.utils.Expect
+import kage.test.utils.Expect.HMACFailure
+import kage.test.utils.Expect.HeaderFailure
+import kage.test.utils.Expect.NoMatch
+import kage.test.utils.Expect.PayloadFailure
+import org.bouncycastle.crypto.InvalidCipherTextException
+
+private inline fun <reified T : Exception> hasCause(error: Throwable): Boolean {
+  var cause = error.cause
+  while(cause != null) {
+    if (error.cause is T) return true
+    cause = cause.cause
+  }
+  return false
+}
+
+fun mapToUpstreamExpect(error: Throwable): Expect {
+  if (error is InvalidIdentityException && hasCause<InvalidCipherTextException>(error)) return NoMatch
+  if (error is IncorrectHMACException || hasCause<IncorrectHMACException>(error)) return HeaderFailure
+  if (error is IncorrectIdentityException) return NoMatch
+  if (error is StreamException) return PayloadFailure
+  if (error is ParseException) return HeaderFailure
+  if (error is CryptoException) return HeaderFailure
+
+  // TODO: Handle cases where we are throwing anything other than CryptoException or ParseException
+  // throw IllegalStateException("Only exceptions thrown by kage can be mapped to expect value")
+  return HeaderFailure
+
+//  return when (this) {
+//    is CryptoException -> {
+//      when (this) {
+//        is IncorrectCipherTextSizeException -> HeaderFailure
+//        is IncorrectIdentityException -> NoMatch
+//        is InvalidBase64StringException -> HeaderFailure
+//        is InvalidIdentityException -> HeaderFailure
+//        is InvalidScryptRecipientException -> HeaderFailure
+//        is NoIdentitiesException -> HeaderFailure
+//        is NoRecipientsException -> HeaderFailure
+//        is ScryptIdentityException -> if (hasCause<InvalidCipherTextException>(this)) NoMatch else HeaderFailure
+//        is StreamException -> PayloadFailure
+//        is X25519IdentityException -> /*if (hasCause<InvalidCipherTextException>(this)) NoMatch else*/ HeaderFailure
+//        is X25519LowOrderPointException -> HeaderFailure
+//        is IncorrectHMACException -> HMACFailure
+//      }
+//    }
+//
+//    is ParseException -> {
+//      when (this) {
+//        is InvalidAgeKeyException -> Expect.HeaderFailure
+//        is InvalidArbitraryStringException -> Expect.HeaderFailure
+//        is InvalidFooterException -> Expect.HeaderFailure
+//        is InvalidHMACException -> Expect.HeaderFailure
+//        is InvalidRecipientException -> Expect.HeaderFailure
+//        is InvalidVersionException -> Expect.HeaderFailure
+//      }
+//    }
+//
+//    else -> {
+//    }
+//  }
+}

--- a/src/test/kotlin/kage/utils/Extensions.kt
+++ b/src/test/kotlin/kage/utils/Extensions.kt
@@ -45,7 +45,7 @@ fun mapToUpstreamExpect(error: Throwable): Expect {
   if (error is CryptoException) return HeaderFailure
 
   // TODO: Handle cases where we are throwing anything other than CryptoException or ParseException
-  // throw IllegalStateException("Only exceptions thrown by kage can be mapped to expect value")
+  //  throw IllegalStateException("Only exceptions thrown by kage can be mapped to expect value")
   return HeaderFailure
 
 //  return when (this) {

--- a/src/test/kotlin/kage/utils/Extensions.kt
+++ b/src/test/kotlin/kage/utils/Extensions.kt
@@ -8,10 +8,12 @@ package kage.kage.utils
 import kage.errors.CryptoException
 import kage.errors.IncorrectHMACException
 import kage.errors.IncorrectIdentityException
+import kage.errors.InvalidHMACHeaderException
 import kage.errors.InvalidIdentityException
 import kage.errors.ParseException
 import kage.errors.StreamException
 import kage.test.utils.Expect
+import kage.test.utils.Expect.HMACFailure
 import kage.test.utils.Expect.HeaderFailure
 import kage.test.utils.Expect.NoMatch
 import kage.test.utils.Expect.PayloadFailure
@@ -30,6 +32,8 @@ fun mapToUpstreamExpect(error: Throwable): Expect {
   if (error is InvalidIdentityException && hasCause<InvalidCipherTextException>(error))
     return NoMatch
   if (error is IncorrectHMACException || hasCause<IncorrectHMACException>(error))
+    return HMACFailure
+  if (error is InvalidHMACHeaderException)
     return HeaderFailure
   if (error is IncorrectIdentityException) return NoMatch
   if (error is StreamException) return PayloadFailure


### PR DESCRIPTION
We're not doing too hot on here, with 40 of 114 tests failing currently.

Changing the fail-fast for armor to a pass instead brings that down considerably to 11/114 failing, so I guess supporting armor is a low-hanging fruit that will have a large impact on our conformance.

Edit: I've updated the implementation to skip all armor tests which changes the status to ~~11~~ ~~6~~ ~~3~~ 19 of 85 tests failing.