### PR TITLE
Add Age.encryptStream overload with a writer callback for dynamic data

### DIFF
--- a/api/kage.api
+++ b/api/kage.api
@@ -5,7 +5,9 @@ public final class kage/Age {
 	public static final fun decryptStream (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;)V
 	public static final fun encrypt (Ljava/util/List;Ljava/io/InputStream;)Lkage/format/AgeFile;
 	public static final fun encryptStream (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;Z)V
+	public static final fun encryptStream (Ljava/util/List;Ljava/io/OutputStream;ZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun encryptStream$default (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;ZILjava/lang/Object;)V
+	public static synthetic fun encryptStream$default (Ljava/util/List;Ljava/io/OutputStream;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public abstract interface class kage/Identity {

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -35,15 +35,27 @@ public object Age {
   @JvmStatic
   public fun encryptStream(
     recipients: List<Recipient>,
-    inputStream: InputStream,
     outputStream: OutputStream,
     generateArmor: Boolean = false,
+    writeInputTo: (OutputStream) -> Unit,
   ) {
     val dstStream = if (generateArmor) ArmorOutputStream(outputStream) else outputStream
 
     val (_, stream) = encryptInternal(recipients, dstStream)
 
-    stream.use { output -> inputStream.use { input -> input.copyTo(output) } }
+    stream.use { output -> writeInputTo(output) }
+  }
+
+  @JvmStatic
+  public fun encryptStream(
+    recipients: List<Recipient>,
+    inputStream: InputStream,
+    outputStream: OutputStream,
+    generateArmor: Boolean = false,
+  ) {
+    encryptStream(recipients, outputStream, generateArmor) { output ->
+      inputStream.use { input -> input.copyTo(output) }
+    }
   }
 
   @JvmStatic

--- a/src/test/kotlin/AgeTest.kt
+++ b/src/test/kotlin/AgeTest.kt
@@ -94,7 +94,8 @@ class AgeTest {
 
     Age.decryptStream(listOf(identity), encryptedInput, decryptedOutput)
 
-    assertThat(decryptedOutput.toByteArray().decodeToString()).isEqualTo("this is my dynamically generated data. Time $now")
+    assertThat(decryptedOutput.toByteArray().decodeToString())
+      .isEqualTo("this is my dynamically generated data. Time $now")
   }
 
   @Test

--- a/src/test/kotlin/AgeTest.kt
+++ b/src/test/kotlin/AgeTest.kt
@@ -75,6 +75,29 @@ class AgeTest {
   }
 
   @Test
+  fun testEncryptWithLambda() {
+    val (recipient, identity) = genX25519Identity()
+
+    val recipients = listOf(recipient)
+
+    val baos = ByteArrayOutputStream()
+
+    val now = System.currentTimeMillis()
+    Age.encryptStream(recipients, baos) { output ->
+      output.write("this is my ".toByteArray())
+      output.write("dynamically generated data. ".toByteArray())
+      output.write("Time $now".toByteArray())
+    }
+
+    val encryptedInput = ByteArrayInputStream(baos.toByteArray())
+    val decryptedOutput = ByteArrayOutputStream()
+
+    Age.decryptStream(listOf(identity), encryptedInput, decryptedOutput)
+
+    assertThat(decryptedOutput.toByteArray().decodeToString()).isEqualTo("this is my dynamically generated data. Time $now")
+  }
+
+  @Test
   fun testScryptEncryptDecryptExactBlockSizeMultiple() {
     val (recipient, identity) = genX25519Identity()
 


### PR DESCRIPTION
I'm using Kage to encrypt a zip file export that's dynamically produced with `ZipOutputStream`, and I'd like to avoid buffering the whole thing before encrypting it. `Age.encryptStream` requiring an InputStream makes this awkward. 

My ideal interface is if Kage allows me to pass a lambda that writes out directly to the OutputStream Kage has internally.

Currently I can get my desired interface by working around it using `PipedOutputStream`/`PipedInputStream` like below:

```kotlin
suspend fun Age.encryptStreamWith(
    recipients: List<Recipient>,
    outputStream: OutputStream,
    writeTo: suspend (OutputStream) -> Unit,
) {
    coroutineScope {
        val pipeInput = PipedInputStream(64 * 1024)
        val pipeOutput = PipedOutputStream(pipeInput)

        val encryptionJob = async(Dispatchers.IO) {
            Age.encryptStream(recipients, pipeInput, outputStream)
        }

        try {
            writeTo(pipeOutput)
        } catch (e: Throwable) {
            pipeInput.close()
            throw e
        }
        encryptionJob.await()
    }
}
```

But this code is awkward and non-obvious, and a small change to Kage can support this use case better.