### PR TITLE
Change encryptStream to return OutputStream

### DIFF
--- a/api/kage.api
+++ b/api/kage.api
@@ -5,9 +5,9 @@ public final class kage/Age {
 	public static final fun decryptStream (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;)V
 	public static final fun encrypt (Ljava/util/List;Ljava/io/InputStream;)Lkage/format/AgeFile;
 	public static final fun encryptStream (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;Z)V
-	public static final fun encryptStream (Ljava/util/List;Ljava/io/OutputStream;ZLkotlin/jvm/functions/Function1;)V
+	public static final fun encryptStream (Ljava/util/List;Ljava/io/OutputStream;Z)Ljava/io/OutputStream;
 	public static synthetic fun encryptStream$default (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;ZILjava/lang/Object;)V
-	public static synthetic fun encryptStream$default (Ljava/util/List;Ljava/io/OutputStream;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun encryptStream$default (Ljava/util/List;Ljava/io/OutputStream;ZILjava/lang/Object;)Ljava/io/OutputStream;
 }
 
 public abstract interface class kage/Identity {

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -37,13 +37,12 @@ public object Age {
     recipients: List<Recipient>,
     outputStream: OutputStream,
     generateArmor: Boolean = false,
-    writeInputTo: (OutputStream) -> Unit,
-  ) {
+  ): OutputStream {
     val dstStream = if (generateArmor) ArmorOutputStream(outputStream) else outputStream
 
     val (_, stream) = encryptInternal(recipients, dstStream)
 
-    stream.use { output -> writeInputTo(output) }
+    return stream
   }
 
   @JvmStatic
@@ -53,7 +52,7 @@ public object Age {
     outputStream: OutputStream,
     generateArmor: Boolean = false,
   ) {
-    encryptStream(recipients, outputStream, generateArmor) { output ->
+    encryptStream(recipients, outputStream, generateArmor).use { output ->
       inputStream.use { input -> input.copyTo(output) }
     }
   }

--- a/src/test/kotlin/AgeTest.kt
+++ b/src/test/kotlin/AgeTest.kt
@@ -75,7 +75,7 @@ class AgeTest {
   }
 
   @Test
-  fun testEncryptWithLambda() {
+  fun testEncryptWithOutputStreamReturnValue() {
     val (recipient, identity) = genX25519Identity()
 
     val recipients = listOf(recipient)
@@ -83,7 +83,7 @@ class AgeTest {
     val baos = ByteArrayOutputStream()
 
     val now = System.currentTimeMillis()
-    Age.encryptStream(recipients, baos) { output ->
+    Age.encryptStream(recipients, baos).use { output ->
       output.write("this is my ".toByteArray())
       output.write("dynamically generated data. ".toByteArray())
       output.write("Time $now".toByteArray())


### PR DESCRIPTION
Improves the API added in #517 by returning the OutputStream, instead of giving it to you in a lambda. A more standard way of using OutputStream, and is more flexible, eg: you could call suspend functions to produce the data to encrypt, which the lambda version didn't permit.