### PR TITLE
OutputStream bulk copy with ByteArray.copyInto()

### DIFF
--- a/src/kotlin/kage/crypto/stream/ArmorOutputStream.kt
+++ b/src/kotlin/kage/crypto/stream/ArmorOutputStream.kt
@@ -16,20 +16,35 @@ internal class ArmorOutputStream(private val dst: OutputStream) : OutputStream()
   private var started = false
 
   override fun write(i: Int) {
+    write(byteArrayOf(i.toByte()))
+  }
+
+  override fun write(b: ByteArray, off: Int, len: Int) {
+    if (len == 0) {
+      return
+    }
+
     if (!started) {
       dst.write((ArmorInputStream.HEADER + "\n").toByteArray())
       started = true
     }
 
-    val b = i.toByte()
+    var inputStart = off
+    val inputEnd = off + len
 
-    if (bufSize == ArmorInputStream.BYTES_PER_LINE) {
-      writeLine()
-      bufSize = 0
+    while (inputStart < inputEnd) {
+      if (bufSize == ArmorInputStream.BYTES_PER_LINE) {
+        writeLine()
+        bufSize = 0
+      }
+
+      val bufSpaceRemaining = ArmorInputStream.BYTES_PER_LINE - bufSize
+      val copyLen = (inputEnd - inputStart).coerceAtMost(bufSpaceRemaining)
+
+      b.copyInto(buf, bufSize, startIndex = inputStart, endIndex = inputStart + copyLen)
+      bufSize += copyLen
+      inputStart += copyLen
     }
-
-    buf[bufSize] = b
-    bufSize++
   }
 
   private fun writeLine() {

--- a/src/kotlin/kage/crypto/stream/ChaCha20Poly1305.kt
+++ b/src/kotlin/kage/crypto/stream/ChaCha20Poly1305.kt
@@ -16,6 +16,8 @@ internal object ChaCha20Poly1305 {
   const val KEY_LENGTH: Int = 32 // bytes
   const val NONCE_LENGTH: Int = 12 // bytes
 
+  internal fun getEncryptOutputSize(inLen: Int) = inLen + MAC_SIZE
+
   fun encrypt(
     key: ByteArray,
     nonce: ByteArray,
@@ -23,18 +25,29 @@ internal object ChaCha20Poly1305 {
     inOff: Int,
     inLen: Int,
   ): ByteArray {
+    val output = ByteArray(getEncryptOutputSize(inLen))
+    encrypt(key, nonce, input, inOff, inLen, output)
+    return output
+  }
+
+  fun encrypt(
+    key: ByteArray,
+    nonce: ByteArray,
+    input: ByteArray,
+    inOff: Int,
+    inLen: Int,
+    output: ByteArray,
+  ): Int {
     val cipher = ChaCha20Poly1305()
     val secKey = KeyParameter(key)
     val params = AEADParameters(secKey, MAC_SIZE * 8, nonce)
 
     cipher.init(true, params)
 
-    val output = ByteArray(cipher.getOutputSize(inLen))
-
     val c = cipher.processBytes(input, inOff, inLen, output, 0)
     cipher.doFinal(output, c)
 
-    return output
+    return getEncryptOutputSize(inLen)
   }
 
   fun aeadEncrypt(key: ByteArray, input: ByteArray): ByteArray {

--- a/src/kotlin/kage/crypto/stream/EncryptOutputStream.kt
+++ b/src/kotlin/kage/crypto/stream/EncryptOutputStream.kt
@@ -26,6 +26,8 @@ internal class EncryptOutputStream(private val key: ByteArray, private val dst: 
   private val buf = ByteArray(CHUNK_SIZE)
   private var bufSize = 0
 
+  private val encryptOutputBuf = ByteArray(ChaCha20Poly1305.getEncryptOutputSize(buf.size))
+
   override fun write(i: Int) {
     write(byteArrayOf(i.toByte()))
   }
@@ -63,9 +65,9 @@ internal class EncryptOutputStream(private val key: ByteArray, private val dst: 
 
     if (last) setLastChunkFlag(nonce)
 
-    val chunk = ChaCha20Poly1305.encrypt(key, nonce, buf, 0, bufSize)
+    val encryptSize = ChaCha20Poly1305.encrypt(key, nonce, buf, 0, bufSize, encryptOutputBuf)
 
-    dst.write(chunk)
+    dst.write(encryptOutputBuf, 0, encryptSize)
 
     incNonce(nonce)
   }

--- a/src/kotlin/kage/crypto/stream/EncryptOutputStream.kt
+++ b/src/kotlin/kage/crypto/stream/EncryptOutputStream.kt
@@ -27,15 +27,26 @@ internal class EncryptOutputStream(private val key: ByteArray, private val dst: 
   private var bufSize = 0
 
   override fun write(i: Int) {
-    val b = i.toByte()
+    write(byteArrayOf(i.toByte()))
+  }
 
-    if (bufSize == CHUNK_SIZE) {
-      flushChunk()
-      bufSize = 0
+  override fun write(b: ByteArray, off: Int, len: Int) {
+    var inputStart = off
+    val inputEnd = off + len
+
+    while (inputStart < inputEnd) {
+      if (bufSize == CHUNK_SIZE) {
+        flushChunk()
+        bufSize = 0
+      }
+
+      val bufSpaceRemaining = CHUNK_SIZE - bufSize
+      val copyLen = (inputEnd - inputStart).coerceAtMost(bufSpaceRemaining)
+
+      b.copyInto(buf, bufSize, startIndex = inputStart, endIndex = inputStart + copyLen)
+      bufSize += copyLen
+      inputStart += copyLen
     }
-
-    buf[bufSize] = b
-    bufSize++
   }
 
   override fun close() {


### PR DESCRIPTION
I noticed that EncryptOutputStream and ArmorOutputStream only override `write(int)`. This means callers using `write(byte[])` use the default `OutputStream.write(byte[])` impl which copies one byte at a time with lots of method call overhead delegating to `write(int)` for each byte. If you can use `ByteArray.copyInto` instead, it's implemented natively, and can go significantly faster than a for loop. I implemented `write(byte[], int, int)` on them and saw about 30% time improvements:

```
size     origin/main      OutputStream-bulk-copy    improvement
1 MiB      7.537 ms          5.164 ms                31.5%
10 MiB    72.916 ms         50.224 ms                31.1%
100 MiB  730.100 ms        496.205 ms                32.0%
```

I also made it re-use the 64KB encryption output ByteArray when calling ChaCha20Poly1305, to get a slight efficiency/allocation overhead gain there too.