### PR TITLE
fix: stream the payload during decryption instead of buffering

### DIFF
--- a/api/kage.api
+++ b/api/kage.api
@@ -159,6 +159,13 @@ public abstract class kage/errors/InvalidIdentityException : kage/errors/CryptoE
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class kage/errors/InvalidNonceException : kage/errors/ParseException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class kage/errors/InvalidRecipientException : kage/errors/ParseException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -19,6 +19,7 @@ import kage.crypto.stream.DecryptInputStream
 import kage.crypto.stream.EncryptOutputStream
 import kage.errors.IncorrectHMACException
 import kage.errors.InvalidHMACHeaderException
+import kage.errors.InvalidNonceException
 import kage.errors.InvalidScryptRecipientException
 import kage.errors.NoIdentitiesException
 import kage.errors.NoRecipientsException
@@ -93,11 +94,8 @@ public object Age {
         ArmorInputStream(markSupportedStream)
       } else markSupportedStream
 
-    val ageFile = AgeFile.parse(decodedStream)
-
-    val input = decryptInternal(identities, ageFile)
-
-    input.use { src -> dstStream.use { dst -> src.copyTo(dst) } }
+    // Parse only the header, then stream the payload — avoids buffering the whole body in memory.
+    decryptStreamInternal(identities, decodedStream.buffered(), dstStream)
   }
 
   @JvmStatic
@@ -207,6 +205,60 @@ public object Age {
       bis.skip(STREAM_NONCE_SIZE.toLong())
 
       return DecryptInputStream(streamKey, bis)
+    }
+
+    throw exceptions.reduce { acc, exception -> acc.apply { addSuppressed(exception) } }
+  }
+
+  // Streaming counterpart of decryptInternal: parses the header off [src], then decrypts the
+  // remaining live stream chunk-by-chunk into [dstStream] without holding the body in memory.
+  private fun decryptStreamInternal(
+    identities: List<Identity>,
+    src: BufferedInputStream,
+    dstStream: OutputStream,
+  ) {
+    if (identities.isEmpty()) throw NoIdentitiesException("no identities specified")
+
+    val header = AgeHeader.parse(src)
+
+    header.recipients.forEach { stanza ->
+      if (stanza.type == ScryptRecipient.SCRYPT_STANZA_TYPE && header.recipients.size != 1)
+        throw ScryptIdentityException("an scrypt identity must be the only one")
+    }
+
+    val exceptions = mutableListOf<Exception>()
+
+    for (identity in identities) {
+      val fileKey =
+        try {
+          identity.unwrap(header.recipients)
+        } catch (err: Exception) {
+          exceptions.add(err)
+          continue
+        }
+
+      if (header.mac.size != HMAC_SIZE) throw InvalidHMACHeaderException("invalid header mac")
+
+      val calculatedMac = Primitives.headerMAC(fileKey, header)
+
+      if (!MessageDigest.isEqual(header.mac, calculatedMac))
+        throw IncorrectHMACException("bad header MAC")
+
+      val nonce = ByteArray(STREAM_NONCE_SIZE)
+      var nonceOffset = 0
+      while (nonceOffset < STREAM_NONCE_SIZE) {
+        val read = src.read(nonce, nonceOffset, STREAM_NONCE_SIZE - nonceOffset)
+        if (read == -1)
+          throw InvalidNonceException("could not read payload nonce: stream truncated")
+        nonceOffset += read
+      }
+
+      val streamKey = Primitives.streamKey(fileKey, nonce)
+
+      DecryptInputStream(streamKey, src).use { decrypted ->
+        dstStream.use { dst -> decrypted.copyTo(dst) }
+      }
+      return
     }
 
     throw exceptions.reduce { acc, exception -> acc.apply { addSuppressed(exception) } }

--- a/src/kotlin/kage/errors/ParseException.kt
+++ b/src/kotlin/kage/errors/ParseException.kt
@@ -42,3 +42,12 @@ constructor(message: String? = null, cause: Throwable? = null) : ParseException(
 public class InvalidAgeKeyException
 @JvmOverloads
 constructor(message: String? = null, cause: Throwable? = null) : ParseException(message, cause)
+
+/**
+ * Raised when the payload nonce cannot be read after the header. age reads the nonce as the final
+ * step of header processing, so a missing or truncated nonce is treated as a header failure rather
+ * than a payload failure.
+ */
+public class InvalidNonceException
+@JvmOverloads
+constructor(message: String? = null, cause: Throwable? = null) : ParseException(message, cause)


### PR DESCRIPTION
`Age.decryptStream` currently goes through `AgeFile.parse`, which reads the whole ciphertext body into a `ByteArrayOutputStream` and then copies it again with `toByteArray()`. Peak memory ends up around 2-3x the file size. On memory-constrained environments that OOMs for large files. I ran into it building an Android app on top of kage, where decrypting a moderately large file crashes the process.

This change parses only the header off the stream and wraps the remaining live input in `DecryptInputStream`, which is how the reference age and rage implementations do it. Memory use is now constant in the file size (one STREAM chunk at a time). `encryptStream` already streamed; only the decrypt path buffered.

One related change: a missing or truncated payload nonce now throws `InvalidNonceException`, a new `ParseException` subtype. age reads the nonce as the last step of header processing, so treating a bad nonce as a header failure keeps the behavior aligned with the CCTV test vectors. The full upstream CCTV suite still passes, and `api/kage.api` is updated for the new exception.

The non-streaming `decrypt(identities, AgeFile)` overload is unchanged.

A couple of notes for review:

- The new public API (`InvalidNonceException`) shows up in the `kage.api` diff. If you would rather not widen the surface, I am happy to reuse an existing exception type instead.
- I verified locally with `./gradlew test checkKotlinAbi animalsnifferMain spotlessCheck`. I left the bundled pitest run to CI since it forks a JVM per core and exhausts memory on my machine.
