### PR TITLE
fix: ensure all errors are explicitly thrown

### DIFF
--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -85,6 +85,9 @@ public object Age {
 
     val initialBytes = ByteArray(readLimit)
     val bytesRead = markSupportedStream.read(initialBytes, 0, readLimit)
+    if (bytesRead == -1) {
+      throw InvalidHMACHeaderException("stream was too short")
+    }
     val initialString = String(initialBytes, 0, bytesRead)
 
     markSupportedStream.reset()

--- a/src/kotlin/kage/crypto/scrypt/ScryptIdentity.kt
+++ b/src/kotlin/kage/crypto/scrypt/ScryptIdentity.kt
@@ -47,7 +47,9 @@ constructor(private val password: ByteArray, private val maxWorkFactor: Int = DE
     val digitsRe = "^[1-9][0-9]*$".toRegex()
     if (!stanza.args[1].matches(digitsRe))
       throw ScryptIdentityException("scrypt work factor encoding invalid: ${stanza.args[1]}")
-    val workFactor = stanza.args[1].toInt()
+    val workFactor =
+      stanza.args[1].toIntOrNull()
+        ?: throw ScryptIdentityException("scrypt work factor too large: ${stanza.args[1]}")
 
     if (workFactor > maxWorkFactor)
       throw ScryptIdentityException("scrypt factor too large: $workFactor")

--- a/src/test/kotlin/kage/UpstreamTestSuite.kt
+++ b/src/test/kotlin/kage/UpstreamTestSuite.kt
@@ -50,8 +50,12 @@ class UpstreamTestSuite {
             assertThat(payloadHash.bytes).isEqualTo(expectedHash.bytes)
           }
         } else {
-          error.printStackTrace()
-          val actual = mapToUpstreamExpect(error)
+          val actual =
+            try {
+              mapToUpstreamExpect(error)
+            } catch (_: IllegalArgumentException) {
+              fail { error.stackTraceToString() }
+            }
           assertThat(actual).isEqualTo(expect)
         }
       }

--- a/src/test/kotlin/kage/utils/Extensions.kt
+++ b/src/test/kotlin/kage/utils/Extensions.kt
@@ -41,7 +41,7 @@ fun mapToUpstreamExpect(error: Throwable): Expect {
   if (error is ArmorCodingException) return ArmorFailure
   if (error is CryptoException) return HeaderFailure
 
-  // TODO: Handle cases where we are throwing anything other than CryptoException or ParseException
-  //  throw IllegalStateException("Only exceptions thrown by kage can be mapped to expect value")
-  return HeaderFailure
+  throw IllegalArgumentException(
+    "Only exceptions thrown by kage can be mapped to expect value: ${error.javaClass.name}"
+  )
 }


### PR DESCRIPTION
- **fix: guard against short reads during header validation**
- **fix: throw an explicit error on overflowing workFactor**
- **fix: remove fallback header failure in upstream test**
