### PR TITLE
feat: support ssh-ed25519 and ssh-rsa recipients and identities

### DIFF
--- a/api/kage.api
+++ b/api/kage.api
@@ -42,6 +42,26 @@ public final class kage/crypto/scrypt/ScryptRecipient : kage/Recipient, kage/Rec
 public final class kage/crypto/scrypt/ScryptRecipient$Companion {
 }
 
+public final class kage/crypto/ssh/SshEd25519Identity : kage/Identity {
+	public final fun recipient ()Lkage/crypto/ssh/SshEd25519Recipient;
+	public fun unwrap (Ljava/util/List;)[B
+}
+
+public final class kage/crypto/ssh/SshEd25519Recipient : kage/Recipient {
+	public static final field Companion Lkage/crypto/ssh/SshEd25519Recipient$Companion;
+	public fun wrap ([B)Ljava/util/List;
+}
+
+public final class kage/crypto/ssh/SshEd25519Recipient$Companion {
+	public final fun parse (Ljava/lang/String;)Lkage/crypto/ssh/SshEd25519Recipient;
+}
+
+public final class kage/crypto/ssh/SshKey {
+	public static final field INSTANCE Lkage/crypto/ssh/SshKey;
+	public final fun parseIdentity (Ljava/lang/String;)Lkage/Identity;
+	public final fun parseRecipient (Ljava/lang/String;)Lkage/Recipient;
+}
+
 public final class kage/crypto/x25519/X25519 {
 	public static final field INSTANCE Lkage/crypto/x25519/X25519;
 	public final fun scalarMult ([B[B)[B
@@ -178,6 +198,13 @@ public final class kage/errors/InvalidScryptRecipientException : kage/errors/Cry
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class kage/errors/InvalidSshKeyException : kage/errors/CryptoException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class kage/errors/InvalidVersionException : kage/errors/ParseException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
@@ -211,7 +238,21 @@ public final class kage/errors/ScryptIdentityException : kage/errors/InvalidIden
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class kage/errors/SshIdentityException : kage/errors/InvalidIdentityException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class kage/errors/StreamException : kage/errors/CryptoException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class kage/errors/UnsupportedSshKeyException : kage/errors/CryptoException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V

--- a/api/kage.api
+++ b/api/kage.api
@@ -62,6 +62,20 @@ public final class kage/crypto/ssh/SshKey {
 	public final fun parseRecipient (Ljava/lang/String;)Lkage/Recipient;
 }
 
+public final class kage/crypto/ssh/SshRsaIdentity : kage/Identity {
+	public final fun recipient ()Lkage/crypto/ssh/SshRsaRecipient;
+	public fun unwrap (Ljava/util/List;)[B
+}
+
+public final class kage/crypto/ssh/SshRsaRecipient : kage/Recipient {
+	public static final field Companion Lkage/crypto/ssh/SshRsaRecipient$Companion;
+	public fun wrap ([B)Ljava/util/List;
+}
+
+public final class kage/crypto/ssh/SshRsaRecipient$Companion {
+	public final fun parse (Ljava/lang/String;)Lkage/crypto/ssh/SshRsaRecipient;
+}
+
 public final class kage/crypto/x25519/X25519 {
 	public static final field INSTANCE Lkage/crypto/x25519/X25519;
 	public final fun scalarMult ([B[B)[B

--- a/src/kotlin/kage/crypto/ssh/Ed25519Conversions.kt
+++ b/src/kotlin/kage/crypto/ssh/Ed25519Conversions.kt
@@ -8,6 +8,7 @@ package kage.crypto.ssh
 import java.math.BigInteger
 import java.security.MessageDigest
 import kage.errors.InvalidSshKeyException
+import org.bouncycastle.math.ec.rfc8032.Ed25519
 
 /**
  * Birational maps between the Ed25519 (Edwards) and Curve25519 (Montgomery) forms, matching how age
@@ -25,6 +26,10 @@ internal object Ed25519Conversions {
    */
   fun publicKeyToCurve25519(ed25519PublicKey: ByteArray): ByteArray {
     require(ed25519PublicKey.size == 32) { "ed25519 public key must be 32 bytes" }
+    // Reject off-curve, non-canonical, and low-order keys (e.g. all-zero); they have no usable
+    // Montgomery form and would yield a degenerate X25519 secret.
+    if (!Ed25519.validatePublicKeyFull(ed25519PublicKey, 0))
+      throw InvalidSshKeyException("invalid ssh-ed25519 public key")
     val le = ed25519PublicKey.copyOf()
     le[31] = (le[31].toInt() and 0x7f).toByte() // drop the encoded x sign bit, leaving y
     val y = leToBigInteger(le)

--- a/src/kotlin/kage/crypto/ssh/Ed25519Conversions.kt
+++ b/src/kotlin/kage/crypto/ssh/Ed25519Conversions.kt
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.ssh
+
+import java.math.BigInteger
+import java.security.MessageDigest
+import kage.errors.InvalidSshKeyException
+
+/**
+ * Birational maps between the Ed25519 (Edwards) and Curve25519 (Montgomery) forms, matching how age
+ * derives X25519 keys from SSH Ed25519 keys. age does this with
+ * `edwards25519.Point.BytesMontgomery` for public keys and `SHA-512(seed)` for private keys; we
+ * reproduce both so wrapping/unwrapping interoperates with the reference implementation.
+ */
+internal object Ed25519Conversions {
+  // The field prime for Curve25519/Ed25519: 2^255 - 19.
+  private val P: BigInteger = BigInteger.ONE.shiftLeft(255).subtract(BigInteger.valueOf(19))
+
+  /**
+   * Maps an Ed25519 public key (a 32-byte little-endian encoded Edwards point) to its Curve25519
+   * Montgomery u-coordinate, encoded little-endian. RFC 7748 section 4.1: u = (1 + y) / (1 - y).
+   */
+  fun publicKeyToCurve25519(ed25519PublicKey: ByteArray): ByteArray {
+    require(ed25519PublicKey.size == 32) { "ed25519 public key must be 32 bytes" }
+    val le = ed25519PublicKey.copyOf()
+    le[31] = (le[31].toInt() and 0x7f).toByte() // drop the encoded x sign bit, leaving y
+    val y = leToBigInteger(le)
+    val num = BigInteger.ONE.add(y).mod(P)
+    val den = BigInteger.ONE.subtract(y).mod(P)
+    // den == 0 (i.e. y == 1) is the Edwards identity point, which has no Montgomery u-coordinate;
+    // reject it rather than letting modInverse throw a bare ArithmeticException.
+    if (den.signum() == 0) throw InvalidSshKeyException("invalid ssh-ed25519 public key")
+    val u = num.multiply(den.modInverse(P)).mod(P)
+    return bigIntegerToLe(u)
+  }
+
+  /**
+   * Derives the Curve25519 scalar from an Ed25519 private seed: the low 32 bytes of SHA-512(seed).
+   * Clamping is left to the X25519 scalar multiplication, exactly as age relies on
+   * curve25519.X25519.
+   */
+  fun privateSeedToCurve25519(seed: ByteArray): ByteArray {
+    require(seed.size == 32) { "ed25519 seed must be 32 bytes" }
+    val h = MessageDigest.getInstance("SHA-512").digest(seed)
+    return h.copyOfRange(0, 32)
+  }
+
+  private fun leToBigInteger(le: ByteArray): BigInteger {
+    // Reverse to big-endian and prepend a zero byte so the value is always interpreted as positive.
+    val be = ByteArray(le.size + 1)
+    for (i in le.indices) be[le.size - i] = le[i]
+    return BigInteger(be)
+  }
+
+  private fun bigIntegerToLe(value: BigInteger): ByteArray {
+    val out = ByteArray(32)
+    var v = value
+    val mask = BigInteger.valueOf(0xff)
+    for (i in 0 until 32) {
+      out[i] = v.and(mask).toInt().toByte()
+      v = v.shiftRight(8)
+    }
+    return out
+  }
+}

--- a/src/kotlin/kage/crypto/ssh/SshEd25519Identity.kt
+++ b/src/kotlin/kage/crypto/ssh/SshEd25519Identity.kt
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.ssh
+
+import kage.Age
+import kage.Identity
+import kage.crypto.ssh.SshEd25519Recipient.Companion.CURVE25519_KEY_LEN
+import kage.crypto.ssh.SshEd25519Recipient.Companion.SSH_ED25519_LABEL
+import kage.crypto.ssh.SshEd25519Recipient.Companion.SSH_ED25519_STANZA_TYPE
+import kage.crypto.stream.ChaCha20Poly1305
+import kage.crypto.x25519.X25519
+import kage.errors.IncorrectIdentityException
+import kage.errors.SshIdentityException
+import kage.format.AgeStanza
+import kage.multiUnwrap
+import kage.utils.decodeBase64
+
+/**
+ * An [Identity] backed by an SSH Ed25519 private key, able to unwrap `ssh-ed25519` stanzas produced
+ * by [SshEd25519Recipient] or by the reference age implementation.
+ *
+ * Construct one with [SshKey.parseIdentity]; the raw-bytes constructor is internal so callers go
+ * through key parsing.
+ */
+public class SshEd25519Identity
+internal constructor(
+  private val sshKeyBlob: ByteArray,
+  ed25519PrivateSeed: ByteArray,
+  private val ed25519PublicKey: ByteArray,
+) : Identity {
+
+  private val curveSecret: ByteArray =
+    Ed25519Conversions.privateSeedToCurve25519(ed25519PrivateSeed)
+  private val curvePublicKey: ByteArray = X25519.scalarMultBase(curveSecret)
+  private val ourFingerprint: String = sshFingerprint(sshKeyBlob)
+
+  private fun unwrapSingle(stanza: AgeStanza): ByteArray {
+    if (stanza.type != SSH_ED25519_STANZA_TYPE) throw IncorrectIdentityException()
+
+    // The first arg is the fingerprint of the key the stanza was wrapped to. If it is not ours the
+    // stanza is for a different recipient, and a different identity should get a chance to try it.
+    if (stanza.args.isEmpty() || stanza.args[0] != ourFingerprint)
+      throw IncorrectIdentityException()
+
+    try {
+      if (stanza.args.size != 2) throw SshIdentityException("invalid ssh-ed25519 recipient block")
+
+      val ephemeralPublicKey = stanza.args[1].decodeBase64()
+      if (ephemeralPublicKey.size != CURVE25519_KEY_LEN)
+        throw SshIdentityException("invalid ssh-ed25519 recipient block")
+
+      val label = SSH_ED25519_LABEL.toByteArray()
+
+      var sharedSecret = X25519.scalarMult(curveSecret, ephemeralPublicKey)
+      val tweak = hkdfSha256(sshKeyBlob, EMPTY, label, CURVE25519_KEY_LEN)
+      sharedSecret = X25519.scalarMult(tweak, sharedSecret)
+
+      val salt = ephemeralPublicKey.plus(curvePublicKey)
+      val wrappingKey = hkdfSha256(salt, sharedSecret, label, CURVE25519_KEY_LEN)
+
+      return ChaCha20Poly1305.aeadDecrypt(wrappingKey, stanza.body, Age.FILE_KEY_SIZE)
+    } catch (err: Exception) {
+      if (err is SshIdentityException) throw err
+      throw SshIdentityException("Error occurred while unwrapping stanza", err)
+    }
+  }
+
+  override fun unwrap(stanzas: List<AgeStanza>): ByteArray = multiUnwrap(::unwrapSingle, stanzas)
+
+  public fun recipient(): SshEd25519Recipient = SshEd25519Recipient(sshKeyBlob, ed25519PublicKey)
+
+  private companion object {
+    private val EMPTY = ByteArray(0)
+  }
+}

--- a/src/kotlin/kage/crypto/ssh/SshEd25519Recipient.kt
+++ b/src/kotlin/kage/crypto/ssh/SshEd25519Recipient.kt
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.ssh
+
+import java.security.SecureRandom
+import kage.Recipient
+import kage.crypto.stream.ChaCha20Poly1305
+import kage.crypto.x25519.X25519
+import kage.errors.InvalidSshKeyException
+import kage.format.AgeStanza
+import kage.utils.encodeBase64
+
+/**
+ * A [Recipient] that wraps the file key to an SSH Ed25519 public key, producing an `ssh-ed25519`
+ * stanza compatible with the reference age implementation.
+ *
+ * The Ed25519 public key is converted to its Curve25519 form and an X25519 key agreement is run
+ * with a fresh ephemeral key, mixed with a per-key tweak derived from the SSH key, exactly as age
+ * does.
+ *
+ * Construct one with [parse] (or via [SshEd25519Identity.recipient]); the raw-bytes constructor is
+ * internal so callers go through key parsing.
+ */
+public class SshEd25519Recipient
+internal constructor(
+  private val sshKeyBlob: ByteArray,
+  private val ed25519PublicKey: ByteArray,
+) : Recipient {
+
+  private val curvePublicKey: ByteArray = Ed25519Conversions.publicKeyToCurve25519(ed25519PublicKey)
+
+  override fun wrap(fileKey: ByteArray): List<AgeStanza> {
+    val ephemeralSecret = ByteArray(EPHEMERAL_SECRET_LEN)
+    SecureRandom().nextBytes(ephemeralSecret)
+
+    val ourPublicKey = X25519.scalarMultBase(ephemeralSecret)
+
+    val label = SSH_ED25519_LABEL.toByteArray()
+
+    var sharedSecret = X25519.scalarMult(ephemeralSecret, curvePublicKey)
+    val tweak = hkdfSha256(sshKeyBlob, EMPTY, label, CURVE25519_KEY_LEN)
+    sharedSecret = X25519.scalarMult(tweak, sharedSecret)
+
+    val salt = ourPublicKey.plus(curvePublicKey)
+    val wrappingKey = hkdfSha256(salt, sharedSecret, label, CURVE25519_KEY_LEN)
+
+    val wrappedKey = ChaCha20Poly1305.aeadEncrypt(wrappingKey, fileKey)
+
+    val stanza =
+      AgeStanza(
+        SSH_ED25519_STANZA_TYPE,
+        listOf(sshFingerprint(sshKeyBlob), ourPublicKey.encodeBase64()),
+        wrappedKey,
+      )
+
+    return listOf(stanza)
+  }
+
+  public companion object {
+    internal const val SSH_ED25519_STANZA_TYPE = "ssh-ed25519"
+    internal const val SSH_ED25519_LABEL = "age-encryption.org/v1/ssh-ed25519"
+    internal const val CURVE25519_KEY_LEN = 32 // bytes
+    internal const val EPHEMERAL_SECRET_LEN = 32 // bytes
+    private val EMPTY = ByteArray(0)
+
+    /** Parses a single `authorized_keys`-style `ssh-ed25519 AAAA... [comment]` line. */
+    public fun parse(authorizedKey: String): SshEd25519Recipient {
+      val (type, blob) = SshKey.parseAuthorizedKey(authorizedKey)
+      if (type != SSH_ED25519_STANZA_TYPE) throw InvalidSshKeyException("not an ssh-ed25519 key")
+      val publicKey = SshKey.ed25519PublicKeyFromBlob(blob)
+      return SshEd25519Recipient(blob, publicKey)
+    }
+  }
+}

--- a/src/kotlin/kage/crypto/ssh/SshKey.kt
+++ b/src/kotlin/kage/crypto/ssh/SshKey.kt
@@ -41,14 +41,23 @@ public object SshKey {
   /** Parses an unencrypted OpenSSH private key (PEM) into an [Identity]. */
   public fun parseIdentity(privateKey: String): Identity {
     val blob = decodeOpenSshPem(privateKey)
+    // Normalize low-level wire errors (e.g. truncation) to InvalidSshKeyException, but let the
+    // exceptions we raise on purpose pass through unchanged.
+    return try {
+      readIdentity(blob)
+    } catch (e: InvalidSshKeyException) {
+      throw e
+    } catch (e: UnsupportedSshKeyException) {
+      throw e
+    } catch (e: Exception) {
+      throw InvalidSshKeyException("malformed OpenSSH private key", e)
+    }
+  }
+
+  private fun readIdentity(blob: ByteArray): Identity {
     val reader = SshWireReader(blob)
 
-    val magic =
-      try {
-        reader.readRaw(AUTH_MAGIC.size)
-      } catch (e: Exception) {
-        throw InvalidSshKeyException("not an OpenSSH private key", e)
-      }
+    val magic = reader.readRaw(AUTH_MAGIC.size)
     if (!magic.contentEquals(AUTH_MAGIC))
       throw InvalidSshKeyException("not an OpenSSH private key (bad magic)")
 
@@ -76,6 +85,12 @@ public object SshKey {
         val privateKeyBytes = priv.readString()
         if (privateKeyBytes.size != 64)
           throw InvalidSshKeyException("bad ed25519 private key length")
+        // The private value is seed || public key; its embedded copy and the top-level blob must
+        // both match the in-section public key, else identity and secret material disagree.
+        if (!publicKey.contentEquals(privateKeyBytes.copyOfRange(32, 64)))
+          throw InvalidSshKeyException("ed25519 public key does not match private key")
+        if (!ed25519PublicKeyFromBlob(publicKeyBlob).contentEquals(publicKey))
+          throw InvalidSshKeyException("ed25519 public key does not match private key")
         val seed = privateKeyBytes.copyOfRange(0, 32)
         SshEd25519Identity(publicKeyBlob, seed, publicKey)
       }
@@ -89,6 +104,11 @@ public object SshKey {
         val q = priv.readMpint()
         if (n.bitLength() < SshRsaRecipient.MIN_RSA_BITS)
           throw UnsupportedSshKeyException("RSA keys shorter than 2048 bits are not supported")
+        // The top-level public blob must match the private parameters, else our published
+        // fingerprint wouldn't belong to the key we decrypt with.
+        val outer = rsaPublicKeyFromBlob(publicKeyBlob)
+        if (outer.modulus != n || outer.exponent != e)
+          throw InvalidSshKeyException("rsa public key does not match private key")
         val dp = d.mod(p.subtract(BigInteger.ONE))
         val dq = d.mod(q.subtract(BigInteger.ONE))
         SshRsaIdentity(publicKeyBlob, RSAPrivateCrtKeyParameters(n, e, d, p, q, dp, dq, iqmp))
@@ -97,27 +117,40 @@ public object SshKey {
     }
   }
 
-  /** Reads `<type> <base64-blob> [comment]`, validates the inner type, returns (type, key blob). */
+  /**
+   * Reads an `authorized_keys` line (`[options] <type> <base64-blob> [comment]`), returning (type,
+   * key blob). The optional options field means the type isn't always first, so scan for the field
+   * whose following blob's inner type string matches it.
+   */
   internal fun parseAuthorizedKey(line: String): Pair<String, ByteArray> {
     val fields = line.trim().split(Regex("\\s+"))
-    if (fields.size < 2) throw InvalidSshKeyException("not an SSH public key line")
-    val type = fields[0]
+    for (i in fields.indices) {
+      val parsed = tryParseKeyTypeAt(fields, i)
+      if (parsed != null) return parsed
+    }
+    throw InvalidSshKeyException("not an SSH public key line")
+  }
 
+  /**
+   * Returns (type, blob) if [fields] at [index] names an SSH key type immediately followed by a
+   * base64 blob whose inner type string matches it, otherwise null.
+   */
+  private fun tryParseKeyTypeAt(fields: List<String>, index: Int): Pair<String, ByteArray>? {
+    if (index + 1 >= fields.size) return null
+    val type = fields[index]
     val blob =
       try {
-        Base64.getDecoder().decode(fields[1])
+        Base64.getDecoder().decode(fields[index + 1])
       } catch (e: IllegalArgumentException) {
-        throw InvalidSshKeyException("invalid base64 in SSH public key", e)
+        return null
       }
-
     val inner =
       try {
         String(SshWireReader(blob).readString(), Charsets.US_ASCII)
       } catch (e: Exception) {
-        throw InvalidSshKeyException("malformed SSH public key", e)
+        return null
       }
-    if (inner != type) throw InvalidSshKeyException("SSH key type mismatch ($type vs $inner)")
-
+    if (inner != type) return null
     return type to blob
   }
 

--- a/src/kotlin/kage/crypto/ssh/SshKey.kt
+++ b/src/kotlin/kage/crypto/ssh/SshKey.kt
@@ -5,11 +5,14 @@
  */
 package kage.crypto.ssh
 
+import java.math.BigInteger
 import java.util.Base64
 import kage.Identity
 import kage.Recipient
 import kage.errors.InvalidSshKeyException
 import kage.errors.UnsupportedSshKeyException
+import org.bouncycastle.crypto.params.RSAKeyParameters
+import org.bouncycastle.crypto.params.RSAPrivateCrtKeyParameters
 
 /**
  * Parses SSH keys into kage [Recipient]s and [Identity]s.
@@ -30,7 +33,7 @@ public object SshKey {
     val (type, _) = parseAuthorizedKey(authorizedKey)
     return when (type) {
       SSH_ED25519 -> SshEd25519Recipient.parse(authorizedKey)
-      SSH_RSA -> throw UnsupportedSshKeyException("ssh-rsa recipients are not yet supported")
+      SSH_RSA -> SshRsaRecipient.parse(authorizedKey)
       else -> throw UnsupportedSshKeyException("unsupported SSH key type: $type")
     }
   }
@@ -76,7 +79,20 @@ public object SshKey {
         val seed = privateKeyBytes.copyOfRange(0, 32)
         SshEd25519Identity(publicKeyBlob, seed, publicKey)
       }
-      SSH_RSA -> throw UnsupportedSshKeyException("ssh-rsa identities are not yet supported")
+      SSH_RSA -> {
+        // OpenSSH serializes the RSA private key as mpints in the order n, e, d, iqmp, p, q.
+        val n = priv.readMpint()
+        val e = priv.readMpint()
+        val d = priv.readMpint()
+        val iqmp = priv.readMpint()
+        val p = priv.readMpint()
+        val q = priv.readMpint()
+        if (n.bitLength() < SshRsaRecipient.MIN_RSA_BITS)
+          throw UnsupportedSshKeyException("RSA keys shorter than 2048 bits are not supported")
+        val dp = d.mod(p.subtract(BigInteger.ONE))
+        val dq = d.mod(q.subtract(BigInteger.ONE))
+        SshRsaIdentity(publicKeyBlob, RSAPrivateCrtKeyParameters(n, e, d, p, q, dp, dq, iqmp))
+      }
       else -> throw UnsupportedSshKeyException("unsupported SSH key type: $keyType")
     }
   }
@@ -112,6 +128,17 @@ public object SshKey {
     val publicKey = reader.readString()
     if (publicKey.size != 32) throw InvalidSshKeyException("bad ed25519 public key length")
     return publicKey
+  }
+
+  /** Builds an RSA public key from its SSH wire blob (`string "ssh-rsa", mpint e, mpint n`). */
+  internal fun rsaPublicKeyFromBlob(blob: ByteArray): RSAKeyParameters {
+    val reader = SshWireReader(blob)
+    reader.readString() // type
+    val e = reader.readMpint()
+    val n = reader.readMpint()
+    if (n.bitLength() < SshRsaRecipient.MIN_RSA_BITS)
+      throw UnsupportedSshKeyException("RSA keys shorter than 2048 bits are not supported")
+    return RSAKeyParameters(false, n, e)
   }
 
   private fun decodeOpenSshPem(pem: String): ByteArray {

--- a/src/kotlin/kage/crypto/ssh/SshKey.kt
+++ b/src/kotlin/kage/crypto/ssh/SshKey.kt
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.ssh
+
+import java.util.Base64
+import kage.Identity
+import kage.Recipient
+import kage.errors.InvalidSshKeyException
+import kage.errors.UnsupportedSshKeyException
+
+/**
+ * Parses SSH keys into kage [Recipient]s and [Identity]s.
+ *
+ * Public keys are read from a single `authorized_keys`-style line (`ssh-ed25519 AAAA... comment`).
+ * Private keys are read from the unencrypted OpenSSH private key format (`-----BEGIN OPENSSH
+ * PRIVATE KEY-----`). Passphrase-encrypted private keys are not yet supported.
+ */
+public object SshKey {
+  private const val SSH_ED25519 = "ssh-ed25519"
+  private const val SSH_RSA = "ssh-rsa"
+
+  // The fixed OpenSSH private key magic: the ASCII "openssh-key-v1" followed by a NUL byte.
+  private val AUTH_MAGIC = "openssh-key-v1".toByteArray(Charsets.US_ASCII).plus(0x00.toByte())
+
+  /** Parses an `authorized_keys`-style public key line into a [Recipient]. */
+  public fun parseRecipient(authorizedKey: String): Recipient {
+    val (type, _) = parseAuthorizedKey(authorizedKey)
+    return when (type) {
+      SSH_ED25519 -> SshEd25519Recipient.parse(authorizedKey)
+      SSH_RSA -> throw UnsupportedSshKeyException("ssh-rsa recipients are not yet supported")
+      else -> throw UnsupportedSshKeyException("unsupported SSH key type: $type")
+    }
+  }
+
+  /** Parses an unencrypted OpenSSH private key (PEM) into an [Identity]. */
+  public fun parseIdentity(privateKey: String): Identity {
+    val blob = decodeOpenSshPem(privateKey)
+    val reader = SshWireReader(blob)
+
+    val magic =
+      try {
+        reader.readRaw(AUTH_MAGIC.size)
+      } catch (e: Exception) {
+        throw InvalidSshKeyException("not an OpenSSH private key", e)
+      }
+    if (!magic.contentEquals(AUTH_MAGIC))
+      throw InvalidSshKeyException("not an OpenSSH private key (bad magic)")
+
+    val cipherName = String(reader.readString(), Charsets.US_ASCII)
+    val kdfName = String(reader.readString(), Charsets.US_ASCII)
+    reader.readString() // kdf options
+    val numKeys = reader.readUInt32()
+    if (numKeys != 1L) throw UnsupportedSshKeyException("multi-key OpenSSH files are not supported")
+
+    val publicKeyBlob = reader.readString()
+    val privateSection = reader.readString()
+
+    if (cipherName != "none" || kdfName != "none")
+      throw UnsupportedSshKeyException("passphrase-encrypted SSH keys are not supported")
+
+    val priv = SshWireReader(privateSection)
+    val check1 = priv.readUInt32()
+    val check2 = priv.readUInt32()
+    if (check1 != check2) throw InvalidSshKeyException("OpenSSH private key checksum mismatch")
+
+    return when (val keyType = String(priv.readString(), Charsets.US_ASCII)) {
+      SSH_ED25519 -> {
+        val publicKey = priv.readString()
+        if (publicKey.size != 32) throw InvalidSshKeyException("bad ed25519 public key length")
+        val privateKeyBytes = priv.readString()
+        if (privateKeyBytes.size != 64)
+          throw InvalidSshKeyException("bad ed25519 private key length")
+        val seed = privateKeyBytes.copyOfRange(0, 32)
+        SshEd25519Identity(publicKeyBlob, seed, publicKey)
+      }
+      SSH_RSA -> throw UnsupportedSshKeyException("ssh-rsa identities are not yet supported")
+      else -> throw UnsupportedSshKeyException("unsupported SSH key type: $keyType")
+    }
+  }
+
+  /** Reads `<type> <base64-blob> [comment]`, validates the inner type, returns (type, key blob). */
+  internal fun parseAuthorizedKey(line: String): Pair<String, ByteArray> {
+    val fields = line.trim().split(Regex("\\s+"))
+    if (fields.size < 2) throw InvalidSshKeyException("not an SSH public key line")
+    val type = fields[0]
+
+    val blob =
+      try {
+        Base64.getDecoder().decode(fields[1])
+      } catch (e: IllegalArgumentException) {
+        throw InvalidSshKeyException("invalid base64 in SSH public key", e)
+      }
+
+    val inner =
+      try {
+        String(SshWireReader(blob).readString(), Charsets.US_ASCII)
+      } catch (e: Exception) {
+        throw InvalidSshKeyException("malformed SSH public key", e)
+      }
+    if (inner != type) throw InvalidSshKeyException("SSH key type mismatch ($type vs $inner)")
+
+    return type to blob
+  }
+
+  /** Extracts the 32-byte Ed25519 public key from its SSH wire blob. */
+  internal fun ed25519PublicKeyFromBlob(blob: ByteArray): ByteArray {
+    val reader = SshWireReader(blob)
+    reader.readString() // type
+    val publicKey = reader.readString()
+    if (publicKey.size != 32) throw InvalidSshKeyException("bad ed25519 public key length")
+    return publicKey
+  }
+
+  private fun decodeOpenSshPem(pem: String): ByteArray {
+    val begin = "-----BEGIN OPENSSH PRIVATE KEY-----"
+    val end = "-----END OPENSSH PRIVATE KEY-----"
+    val start = pem.indexOf(begin)
+    val finish = pem.indexOf(end)
+    if (start < 0 || finish < 0 || finish < start)
+      throw InvalidSshKeyException("not an OpenSSH private key (missing PEM markers)")
+    val body = pem.substring(start + begin.length, finish).replace(Regex("\\s"), "")
+    return try {
+      Base64.getDecoder().decode(body)
+    } catch (e: IllegalArgumentException) {
+      throw InvalidSshKeyException("invalid base64 in OpenSSH private key", e)
+    }
+  }
+}

--- a/src/kotlin/kage/crypto/ssh/SshRsaIdentity.kt
+++ b/src/kotlin/kage/crypto/ssh/SshRsaIdentity.kt
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.ssh
+
+import kage.Identity
+import kage.crypto.ssh.SshRsaRecipient.Companion.SSH_RSA_STANZA_TYPE
+import kage.errors.IncorrectIdentityException
+import kage.errors.SshIdentityException
+import kage.format.AgeStanza
+import kage.multiUnwrap
+import org.bouncycastle.crypto.params.RSAKeyParameters
+import org.bouncycastle.crypto.params.RSAPrivateCrtKeyParameters
+
+/**
+ * An [Identity] backed by an SSH RSA private key, able to unwrap `ssh-rsa` stanzas produced by
+ * [SshRsaRecipient] or by the reference age implementation.
+ *
+ * Construct one with [SshKey.parseIdentity]; the raw-key constructor is internal so callers go
+ * through key parsing.
+ */
+public class SshRsaIdentity
+internal constructor(
+  private val sshKeyBlob: ByteArray,
+  private val privateKey: RSAPrivateCrtKeyParameters,
+) : Identity {
+
+  private val ourFingerprint: String = sshFingerprint(sshKeyBlob)
+
+  private fun unwrapSingle(stanza: AgeStanza): ByteArray {
+    if (stanza.type != SSH_RSA_STANZA_TYPE) throw IncorrectIdentityException()
+
+    // The single arg is the fingerprint of the key the stanza was wrapped to. If it is not ours the
+    // stanza is for a different recipient, and a different identity should get a chance to try it.
+    if (stanza.args.size != 1 || stanza.args[0] != ourFingerprint)
+      throw IncorrectIdentityException()
+
+    try {
+      val oaep = SshRsaRecipient.oaep()
+      oaep.init(false, privateKey)
+      return oaep.processBlock(stanza.body, 0, stanza.body.size)
+    } catch (err: Exception) {
+      throw SshIdentityException("Error occurred while unwrapping stanza", err)
+    }
+  }
+
+  override fun unwrap(stanzas: List<AgeStanza>): ByteArray = multiUnwrap(::unwrapSingle, stanzas)
+
+  public fun recipient(): SshRsaRecipient {
+    val publicKey = RSAKeyParameters(false, privateKey.modulus, privateKey.publicExponent)
+    return SshRsaRecipient(sshKeyBlob, publicKey)
+  }
+}

--- a/src/kotlin/kage/crypto/ssh/SshRsaRecipient.kt
+++ b/src/kotlin/kage/crypto/ssh/SshRsaRecipient.kt
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.ssh
+
+import kage.Recipient
+import kage.errors.InvalidSshKeyException
+import kage.format.AgeStanza
+import org.bouncycastle.crypto.digests.SHA256Digest
+import org.bouncycastle.crypto.encodings.OAEPEncoding
+import org.bouncycastle.crypto.engines.RSAEngine
+import org.bouncycastle.crypto.params.RSAKeyParameters
+
+/**
+ * A [Recipient] that wraps the file key to an SSH RSA public key, producing an `ssh-rsa` stanza
+ * compatible with the reference age implementation.
+ *
+ * The file key is encrypted with RSA-OAEP (SHA-256, MGF1-SHA256, label
+ * `age-encryption.org/v1/ssh-rsa`), exactly as age does.
+ *
+ * Construct one with [parse] (or via [SshRsaIdentity.recipient]); the raw-key constructor is
+ * internal so callers go through key parsing.
+ */
+public class SshRsaRecipient
+internal constructor(
+  private val sshKeyBlob: ByteArray,
+  private val publicKey: RSAKeyParameters,
+) : Recipient {
+
+  override fun wrap(fileKey: ByteArray): List<AgeStanza> {
+    val oaep = oaep()
+    oaep.init(true, publicKey)
+    val wrappedKey = oaep.processBlock(fileKey, 0, fileKey.size)
+
+    val stanza = AgeStanza(SSH_RSA_STANZA_TYPE, listOf(sshFingerprint(sshKeyBlob)), wrappedKey)
+    return listOf(stanza)
+  }
+
+  public companion object {
+    internal const val SSH_RSA_STANZA_TYPE = "ssh-rsa"
+    internal const val SSH_RSA_LABEL = "age-encryption.org/v1/ssh-rsa"
+
+    // age (like OpenSSH and current best practice) rejects RSA keys below 2048 bits.
+    internal const val MIN_RSA_BITS = 2048
+
+    /**
+     * Builds the RSA-OAEP scheme age uses for `ssh-rsa`: SHA-256 as the hash, MGF1 also over
+     * SHA-256, and the age label as the OAEP encoding parameter. Using the BouncyCastle lightweight
+     * API (rather than a JCA `Cipher`) keeps the MGF1 digest pinned to SHA-256 on every platform —
+     * some JCA providers, notably Android's, silently fall back to MGF1-SHA1 and break interop.
+     */
+    internal fun oaep(): OAEPEncoding =
+      OAEPEncoding(RSAEngine(), SHA256Digest(), SHA256Digest(), SSH_RSA_LABEL.toByteArray())
+
+    /** Parses a single `authorized_keys`-style `ssh-rsa AAAA... [comment]` line. */
+    public fun parse(authorizedKey: String): SshRsaRecipient {
+      val (type, blob) = SshKey.parseAuthorizedKey(authorizedKey)
+      if (type != SSH_RSA_STANZA_TYPE) throw InvalidSshKeyException("not an ssh-rsa key")
+      val publicKey = SshKey.rsaPublicKeyFromBlob(blob)
+      return SshRsaRecipient(blob, publicKey)
+    }
+  }
+}

--- a/src/kotlin/kage/crypto/ssh/SshWire.kt
+++ b/src/kotlin/kage/crypto/ssh/SshWire.kt
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.ssh
+
+import java.io.EOFException
+import java.math.BigInteger
+import java.security.MessageDigest
+import kage.utils.encodeBase64
+import org.bouncycastle.crypto.digests.SHA256Digest
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator
+import org.bouncycastle.crypto.params.HKDFParameters
+
+/**
+ * Minimal reader for the SSH wire encoding (RFC 4251 section 5): fixed-width [readRaw], 32-bit
+ * lengths ([readUInt32]), length-prefixed byte strings ([readString]) and multiple-precision
+ * integers ([readMpint]). Only what is needed to parse OpenSSH public and private keys.
+ */
+internal class SshWireReader(private val buf: ByteArray) {
+  private var pos = 0
+
+  fun readRaw(n: Int): ByteArray {
+    if (n < 0 || pos + n > buf.size) throw EOFException("ssh wire: truncated bytes")
+    val out = buf.copyOfRange(pos, pos + n)
+    pos += n
+    return out
+  }
+
+  fun readUInt32(): Long {
+    val b = readRaw(4)
+    return ((b[0].toLong() and 0xff) shl 24) or
+      ((b[1].toLong() and 0xff) shl 16) or
+      ((b[2].toLong() and 0xff) shl 8) or
+      (b[3].toLong() and 0xff)
+  }
+
+  fun readString(): ByteArray {
+    val len = readUInt32()
+    if (len > Int.MAX_VALUE) throw EOFException("ssh wire: string too long")
+    return readRaw(len.toInt())
+  }
+
+  /** Reads an mpint: a length-prefixed, signed, big-endian two's-complement integer. */
+  fun readMpint(): BigInteger {
+    val b = readString()
+    return if (b.isEmpty()) BigInteger.ZERO else BigInteger(b)
+  }
+
+  fun remaining(): Int = buf.size - pos
+}
+
+/**
+ * The age "SSH fingerprint": the first 4 bytes of the SHA-256 of the SSH wire encoding of the
+ * public key, base64-encoded (raw, unpadded). Used as the recipient stanza tag so an identity can
+ * tell whether a stanza was wrapped to its key.
+ */
+internal fun sshFingerprint(sshKeyBlob: ByteArray): String {
+  val digest = MessageDigest.getInstance("SHA-256").digest(sshKeyBlob)
+  return digest.copyOfRange(0, 4).encodeBase64()
+}
+
+/**
+ * HKDF-SHA256 (RFC 5869) extract-and-expand. Uses BouncyCastle rather than the at.favre HKDF used
+ * elsewhere because age's SSH key derivation runs an extract step with empty input keying material
+ * (the per-key tweak), which the favre implementation rejects.
+ */
+internal fun hkdfSha256(salt: ByteArray, ikm: ByteArray, info: ByteArray, length: Int): ByteArray {
+  val hkdf = HKDFBytesGenerator(SHA256Digest())
+  hkdf.init(HKDFParameters(ikm, salt, info))
+  val out = ByteArray(length)
+  hkdf.generateBytes(out, 0, length)
+  return out
+}

--- a/src/kotlin/kage/errors/CryptoException.kt
+++ b/src/kotlin/kage/errors/CryptoException.kt
@@ -41,6 +41,25 @@ public class X25519IdentityException
 constructor(message: String? = null, cause: Throwable? = null) :
   InvalidIdentityException(message, cause)
 
+/** Raised when an error occurs when unwrapping an SSH stanza from an [kage.Identity]. */
+public class SshIdentityException
+@JvmOverloads
+constructor(message: String? = null, cause: Throwable? = null) :
+  InvalidIdentityException(message, cause)
+
+/** Raised when an SSH key cannot be parsed into a [kage.Recipient] or [kage.Identity]. */
+public class InvalidSshKeyException
+@JvmOverloads
+constructor(message: String? = null, cause: Throwable? = null) : CryptoException(message, cause)
+
+/**
+ * Raised when an SSH key is well-formed but not supported, e.g. a passphrase-encrypted private key
+ * or an unsupported key type.
+ */
+public class UnsupportedSshKeyException
+@JvmOverloads
+constructor(message: String? = null, cause: Throwable? = null) : CryptoException(message, cause)
+
 /**
  * Raised when an error occurs while calculating the X25519 shared secret. If the X25519 share is a
  * low order point, the shared secret is the disallowed all-zero value.

--- a/src/test/kotlin/kage/crypto/ssh/SshEd25519Test.kt
+++ b/src/test/kotlin/kage/crypto/ssh/SshEd25519Test.kt
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.kage.crypto.ssh
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayInputStream
+import java.util.Random
+import kage.Age
+import kage.crypto.ssh.SshEd25519Identity
+import kage.crypto.ssh.SshEd25519Recipient
+import kage.crypto.ssh.SshKey
+import kage.errors.InvalidSshKeyException
+import kage.format.AgeFile
+import org.bouncycastle.util.encoders.Base64
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SshEd25519Test {
+  // A fixed Ed25519 keypair generated with `ssh-keygen -t ed25519`, used so the tests exercise real
+  // OpenSSH encodings rather than synthetic ones.
+  private val publicKey =
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHG8mlXinVA7JAjGA18TFKWPJKS5j+PhrHswLtTBp/z/ kage-ssh-test"
+
+  private val privateKey =
+    """
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACBxvJpV4p1QOyQIxgNfExSljySkuY/j4ax7MC7Uwaf8/wAAAJBbYMrcW2DK
+    3AAAAAtzc2gtZWQyNTUxOQAAACBxvJpV4p1QOyQIxgNfExSljySkuY/j4ax7MC7Uwaf8/w
+    AAAECtl1fcB70WPqhj3qCXQWV/RQOWjMbMD5ybfLOgH+SwenG8mlXinVA7JAjGA18TFKWP
+    JKS5j+PhrHswLtTBp/z/AAAADWthZ2Utc3NoLXRlc3Q=
+    -----END OPENSSH PRIVATE KEY-----
+    """
+      .trimIndent()
+
+  @Test
+  fun testWrapUnwrap() {
+    val recipient = SshEd25519Recipient.parse(publicKey)
+
+    val fileKey = ByteArray(Age.FILE_KEY_SIZE)
+    Random().nextBytes(fileKey)
+
+    val stanza = recipient.wrap(fileKey).single()
+    assertThat(stanza.type).isEqualTo("ssh-ed25519")
+    assertThat(stanza.args).hasSize(2)
+
+    val identity = SshKey.parseIdentity(privateKey)
+    val unwrapped = identity.unwrap(listOf(stanza))
+    assertThat(unwrapped.asList()).containsExactlyElementsIn(fileKey.asList())
+  }
+
+  @Test
+  fun testRecipientFromIdentityRoundTrips() {
+    val identity = SshKey.parseIdentity(privateKey)
+    val recipient = (identity as SshEd25519Identity).recipient()
+
+    val fileKey = ByteArray(Age.FILE_KEY_SIZE)
+    Random().nextBytes(fileKey)
+
+    val stanzas = recipient.wrap(fileKey)
+    assertThat(identity.unwrap(stanzas).asList()).containsExactlyElementsIn(fileKey.asList())
+  }
+
+  @Test
+  fun testAgeRoundTrip() {
+    val recipient = SshKey.parseRecipient(publicKey)
+    val identity = SshKey.parseIdentity(privateKey)
+
+    val plaintext = "the quick brown fox jumps over the lazy dog".toByteArray()
+    val ageFile = Age.encrypt(listOf(recipient), ByteArrayInputStream(plaintext))
+    val decrypted = Age.decrypt(identity, ageFile).readBytes()
+
+    assertThat(decrypted).isEqualTo(plaintext)
+  }
+
+  @Test
+  fun testDecryptsReferenceAgeCiphertext() {
+    // A binary age file produced by the reference age implementation with `age -R <pubKey>` over
+    // the plaintext below. Decrypting it proves byte-level interop of the ssh-ed25519 stanza
+    // (fingerprint tag, HKDF labels, tweak, salt order), which a kage-only round-trip cannot, since
+    // a consistent deviation from age would pass that.
+    val ageEncrypted =
+      Base64.decode(
+        """
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IGgwa0FBUSBxVFlOWmxPd1pFYjNz
+        dVM1bFNmMUtKbkphN2hLZWUzUFlnbktLSnpFTUQwCnBkTittU0lxYTFmZ2tEZnNWY0RpbWdIc1ZL
+        R2F2VmFDMTYyWW9ZTyt3a0kKLS0tIDJ5UmZiRmRtZ2h0MDlFQ2JXOHdvazFIbUY0cDgrTTZzanpS
+        RmtLNTlEV0EKT+YuPQVK+quHMBG6sQ6nR2wO/7ZoWBVjoAlyhJO+1+L7XygyZhVN21hMSEu/43Tt
+        AKmPLCnwnugrkbqhX961
+        """
+          .trimIndent()
+      )
+
+    val identity = SshKey.parseIdentity(privateKey)
+    val ageFile = AgeFile.parse(ByteArrayInputStream(ageEncrypted))
+    val decrypted = Age.decrypt(identity, ageFile).readBytes()
+
+    assertThat(String(decrypted)).isEqualTo("kage ssh-ed25519 interop vector")
+  }
+
+  @Test
+  fun testParseRejectsGarbage() {
+    assertThrows<InvalidSshKeyException> { SshKey.parseRecipient("not a key") }
+    assertThrows<InvalidSshKeyException> {
+      SshKey.parseIdentity(
+        "-----BEGIN OPENSSH PRIVATE KEY-----\nZZZ\n-----END OPENSSH PRIVATE KEY-----"
+      )
+    }
+  }
+}

--- a/src/test/kotlin/kage/crypto/ssh/SshEd25519Test.kt
+++ b/src/test/kotlin/kage/crypto/ssh/SshEd25519Test.kt
@@ -36,6 +36,9 @@ class SshEd25519Test {
     """
       .trimIndent()
 
+  private val alternatePublicKey =
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINkhx96uLzMoBqVWIrLvxT7dZX12UXlFtm3Q/MXnAMPJ test2"
+
   @Test
   fun testWrapUnwrap() {
     val recipient = SshEd25519Recipient.parse(publicKey)
@@ -99,6 +102,37 @@ class SshEd25519Test {
     val decrypted = Age.decrypt(identity, ageFile).readBytes()
 
     assertThat(String(decrypted)).isEqualTo("kage ssh-ed25519 interop vector")
+  }
+
+  @Test
+  fun testParseRecipientAcceptsAuthorizedKeysOptions() {
+    val keyWithOptions = "restrict,command=\"/bin/false\" $publicKey"
+
+    val recipient = SshKey.parseRecipient(keyWithOptions)
+
+    assertThat(recipient).isInstanceOf(SshEd25519Recipient::class.java)
+  }
+
+  @Test
+  fun testParseIdentityRejectsMismatchedEd25519PublicKey() {
+    val tamperedPrivateKey = tamperEd25519PrivateKeyPublicParts(privateKey, alternatePublicKey)
+
+    assertThrows<InvalidSshKeyException> { SshKey.parseIdentity(tamperedPrivateKey) }
+  }
+
+  @Test
+  fun testParseIdentityWrapsTruncatedOpenSshWireErrors() {
+    val truncatedPrivateKey =
+      encodeOpenSshPem("openssh-key-v1\u0000".toByteArray(Charsets.US_ASCII))
+
+    assertThrows<InvalidSshKeyException> { SshKey.parseIdentity(truncatedPrivateKey) }
+  }
+
+  @Test
+  fun testParseRejectsInvalidEd25519PublicKeyPoint() {
+    val invalidPublicKey = buildEd25519AuthorizedKey(ByteArray(32))
+
+    assertThrows<InvalidSshKeyException> { SshEd25519Recipient.parse(invalidPublicKey) }
   }
 
   @Test

--- a/src/test/kotlin/kage/crypto/ssh/SshRsaTest.kt
+++ b/src/test/kotlin/kage/crypto/ssh/SshRsaTest.kt
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.kage.crypto.ssh
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayInputStream
+import java.util.Random
+import kage.Age
+import kage.crypto.ssh.SshKey
+import kage.crypto.ssh.SshRsaIdentity
+import kage.crypto.ssh.SshRsaRecipient
+import kage.errors.InvalidSshKeyException
+import kage.format.AgeFile
+import org.bouncycastle.util.encoders.Base64
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SshRsaTest {
+  // A fixed 2048-bit RSA keypair generated with `ssh-keygen -t rsa -b 2048`, used so the tests
+  // exercise real OpenSSH encodings rather than synthetic ones.
+  private val publicKey =
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWnremrBKJ8WUcIQltVZ4MD65ck7HFKwjAWY6lRAKLOj1ffwX8" +
+      "lY0pIDe2Gry381CsuYIDfS21Iulfn0ZbYnb1qKxDGtwvasCplNv5Ag9JhznbO0aGNOfjXuuJI+ZM3AuZkYKQysEUFT2" +
+      "47Oj9mvcU6qcTDF3E6kYDL2iFVqTUtQ4Vf/JMs4fdsUUqZeeXVl7mav+ctpmLU285qUQJxbHvoFUeUL9J9LnLQrYx4x" +
+      "CdUibW0jvpKzRMcZ7wMz1954Jj2ThYJqBG228hUto9BS++epK40NIeQOvCYLwKM7ejVWI4xcHqNJ2+FZ95gXElkkcgn" +
+      "V/mDNz1KE42kq4LhSeh kage-ssh-rsa-test"
+
+  private val privateKey =
+    """
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
+    NhAAAAAwEAAQAAAQEA1p63pqwSifFlHCEJbVWeDA+uXJOxxSsIwFmOpUQCizo9X38F/JWN
+    KSA3thq8t/NQrLmCA30ttSLpX59GW2J29aisQxrcL2rAqZTb+QIPSYc52ztGhjTn417riS
+    PmTNwLmZGCkMrBFBU9uOzo/Zr3FOqnEwxdxOpGAy9ohVak1LUOFX/yTLOH3bFFKmXnl1Ze
+    5mr/nLaZi1NvOalECcWx76BVHlC/SfS5y0K2MeMQnVIm1tI76Ss0THGe8DM9feeCY9k4WC
+    agRttvIVLaPQUvvnqSuNDSHkDrwmC8CjO3o1ViOMXB6jSdvhWfeYFxJZJHIJ1f5gzc9ShO
+    NpKuC4UnoQAAA8gy8vyOMvL8jgAAAAdzc2gtcnNhAAABAQDWnremrBKJ8WUcIQltVZ4MD6
+    5ck7HFKwjAWY6lRAKLOj1ffwX8lY0pIDe2Gry381CsuYIDfS21Iulfn0ZbYnb1qKxDGtwv
+    asCplNv5Ag9JhznbO0aGNOfjXuuJI+ZM3AuZkYKQysEUFT247Oj9mvcU6qcTDF3E6kYDL2
+    iFVqTUtQ4Vf/JMs4fdsUUqZeeXVl7mav+ctpmLU285qUQJxbHvoFUeUL9J9LnLQrYx4xCd
+    UibW0jvpKzRMcZ7wMz1954Jj2ThYJqBG228hUto9BS++epK40NIeQOvCYLwKM7ejVWI4xc
+    HqNJ2+FZ95gXElkkcgnV/mDNz1KE42kq4LhSehAAAAAwEAAQAAAQAKc8rmbWFuweimdM5w
+    ene6xyW7AP9qppSjx4jMsDH+hVzZUoagXUk1bEoCTq2LuOggLV2xXU6VUIi0nT1wNGyuPK
+    N9FikMjyKob6VB7JGBh3owHOQro5Z6ipQmhu7PpfTTqxREiHdcSseJgtI7DanEZUQzR4om
+    jbFQtOWeftCCwmK9v2+y+HcNt7ill8XaogdJEoAMR4nJg3BJDq9tiVGab5MR0e/dogk4bD
+    8AP5Op/rktAK1Wuqk3Vr7COGySzYhy0/plcAGgl912uCHrpyMfaY0N9k56Ro3ArxykZxmT
+    foRBWqs3OvrnaLqeBW9JtRj5vJcb8Qm7w4twnuB9+z9RAAAAgGsUKAqbhXo+G5aYqa6Tb7
+    DfiBVmmPYd0K9tAiAP4FXIURwU00+eySJMdqe1u7wFPHMWKs1M5rhC5Q3p0XpDlGVMo4Tm
+    2tGI/CB34MASk/V6rCn+D1ShEuTPnh+on0+TSijW3WAvkmqGh4E5r/XkIxNlSgFHMsXmOh
+    pzjAtLL6kyAAAAgQD0phov83echz4QARmnevZojTxb4o4UJNduEY1qHY5Nb3WREXycR5Nx
+    3MGU0SUlq8+z7Mg4ThAGl8IGM+LELQ1DeEHZ/k9Gr1RSgabDpcYk+PybK6Il+beDJfpXQ6
+    3YjevYIEn+SxI6QQrxdb6wggDXpg9dkWgrdh2d42QY/2RimQAAAIEA4JPv//Rw6frFjQCt
+    93N4AsW4GrYpPNQ/01GeP6Wx4I9kX7hKSVewE2tou8vkUuK4bzTiQ6iUt1xXXIDJSCaimi
+    qo5VNfULiX+ID8Q4YY8RnvlSL/6q1oOIcn8lG48d1R+o5QNM0taAJLbK+uCMsoyoG1OPgN
+    h5WEd2erX/tdmkkAAAARa2FnZS1zc2gtcnNhLXRlc3QBAg==
+    -----END OPENSSH PRIVATE KEY-----
+    """
+      .trimIndent()
+
+  @Test
+  fun testWrapUnwrap() {
+    val recipient = SshRsaRecipient.parse(publicKey)
+
+    val fileKey = ByteArray(Age.FILE_KEY_SIZE)
+    Random().nextBytes(fileKey)
+
+    val stanza = recipient.wrap(fileKey).single()
+    assertThat(stanza.type).isEqualTo("ssh-rsa")
+    assertThat(stanza.args).hasSize(1)
+
+    val identity = SshKey.parseIdentity(privateKey)
+    val unwrapped = identity.unwrap(listOf(stanza))
+    assertThat(unwrapped.asList()).containsExactlyElementsIn(fileKey.asList())
+  }
+
+  @Test
+  fun testRecipientFromIdentityRoundTrips() {
+    val identity = SshKey.parseIdentity(privateKey)
+    val recipient = (identity as SshRsaIdentity).recipient()
+
+    val fileKey = ByteArray(Age.FILE_KEY_SIZE)
+    Random().nextBytes(fileKey)
+
+    val stanzas = recipient.wrap(fileKey)
+    assertThat(identity.unwrap(stanzas).asList()).containsExactlyElementsIn(fileKey.asList())
+  }
+
+  @Test
+  fun testAgeRoundTrip() {
+    val recipient = SshKey.parseRecipient(publicKey)
+    val identity = SshKey.parseIdentity(privateKey)
+
+    val plaintext = "the quick brown fox jumps over the lazy dog".toByteArray()
+    val ageFile = Age.encrypt(listOf(recipient), ByteArrayInputStream(plaintext))
+    val decrypted = Age.decrypt(identity, ageFile).readBytes()
+
+    assertThat(decrypted).isEqualTo(plaintext)
+  }
+
+  @Test
+  fun testDecryptsReferenceAgeCiphertext() {
+    // A binary age file produced by the reference age implementation with `age -R <pubKey>` over
+    // the plaintext below. Decrypting it proves byte-level interop of the ssh-rsa stanza
+    // (fingerprint tag, RSA-OAEP with SHA-256/MGF1-SHA256 and the age label), which a kage-only
+    // round-trip cannot, since a consistent deviation from age would still pass that.
+    val ageEncrypted =
+      Base64.decode(
+        """
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1yc2EgZjVvdlJnCkhza044U2hw
+        cDRmM2d0UnppYWRmSGt1NndYYy9lL05iN042L29ySnZVenFYOWRNaTVCejlKVTdI
+        N2x6NWhHVW0KZjQvRWNoVE5uL2dlOGNqNTNTT3BCc2dBMHdGbVNLeFFxQ3Noa04x
+        MlVUTHZiSE1wN0VRblpjTEtZRXBDVm5JVwpSZXBheStWd1JnVCtCQkNTN1Y2Y3R5
+        MGxXT1FzaWNqVEFWRTZ0VThPTnAvMHFtQ2xIc1hqMGVIN3VDdDdSeHVuCmVHYStv
+        QythTVVKbmxXYkNkKytpMHpJbldNd0xXNVpGT2NjK1RiVWFYRnJJMG8rdmxyZHlG
+        Y3N1RHlqRklreXMKdjFaa3lDamtNai8rZEQ0ZkI5Y1dXNFVrc1JTUVpld21CM1V6
+        UFlvWlU4Z1VwUCtmZkFDZGxlNkQ4UEo3MHpVQQpHQWJDZ2Q2Q2l1dHBlc3F4L2hI
+        Qmx3Ci0tLSBkL29EWHFRbU9DR2Zmd1VHR21jNUVXbGRhU1dXRXhmelk3QXNkaUhZ
+        Yzc0Ch/PtV3OSNsKmwZmfp6t9sOSYMui61EIsjPzzb8drkuf2OdIlXOmRMOacVV1
+        W9oRogUbB1v0V0gbt4qt
+        """
+          .trimIndent()
+      )
+
+    val identity = SshKey.parseIdentity(privateKey)
+    val ageFile = AgeFile.parse(ByteArrayInputStream(ageEncrypted))
+    val decrypted = Age.decrypt(identity, ageFile).readBytes()
+
+    assertThat(String(decrypted)).isEqualTo("kage ssh-rsa interop vector")
+  }
+
+  @Test
+  fun testParseRejectsGarbage() {
+    assertThrows<InvalidSshKeyException> { SshRsaRecipient.parse("not a key") }
+  }
+}

--- a/src/test/kotlin/kage/crypto/ssh/SshRsaTest.kt
+++ b/src/test/kotlin/kage/crypto/ssh/SshRsaTest.kt
@@ -60,6 +60,9 @@ class SshRsaTest {
     """
       .trimIndent()
 
+  private val alternatePublicKey =
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCol7YjhrNPP1EFFeV7JfbjwIQBUM+Ky9L+N2qyZLWR1bj7RIk7T4VFnox7tPsKEFS3b3YhsbNWpeiesMczivgzxiYMIsbgYY3LR0Q8+QXvihKSLdnfPxx6EKcL2go5eGtHaJO0IjXILQIsP0ER1OeTIN6aOXvgnq2Pe96D8AGTJltuyvK4TD/CC1WE5F+88Gvy7gH/7vd6QGcQqevXy36dRkyNdHUgcnufOhwQmetDq4gsW4GxNPufzbm1PMVkmA7d87Zwig1JQAV/bcQnHIHNo7QgRds7tjOSIQ7vzl+pTbf677FWlQSR9QziKBuk1TQcTluwOXoYOnOZ9vmy2XTZ test2"
+
   @Test
   fun testWrapUnwrap() {
     val recipient = SshRsaRecipient.parse(publicKey)
@@ -129,6 +132,13 @@ class SshRsaTest {
     val decrypted = Age.decrypt(identity, ageFile).readBytes()
 
     assertThat(String(decrypted)).isEqualTo("kage ssh-rsa interop vector")
+  }
+
+  @Test
+  fun testParseIdentityRejectsMismatchedRsaPublicKey() {
+    val tamperedPrivateKey = tamperRsaPrivateKeyOuterPublicKey(privateKey, alternatePublicKey)
+
+    assertThrows<InvalidSshKeyException> { SshKey.parseIdentity(tamperedPrivateKey) }
   }
 
   @Test

--- a/src/test/kotlin/kage/crypto/ssh/SshTestKeyMutators.kt
+++ b/src/test/kotlin/kage/crypto/ssh/SshTestKeyMutators.kt
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2026 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.kage.crypto.ssh
+
+import java.io.ByteArrayOutputStream
+import java.util.Base64
+import kage.crypto.ssh.SshWireReader
+
+internal fun buildEd25519AuthorizedKey(publicKey: ByteArray, comment: String = "test"): String {
+  val blob =
+    ByteArrayOutputStream().apply {
+      writeSshString("ssh-ed25519".toByteArray(Charsets.US_ASCII))
+      writeSshString(publicKey)
+    }
+
+  return "ssh-ed25519 ${Base64.getEncoder().encodeToString(blob.toByteArray())} $comment"
+}
+
+/**
+ * Rewrites an Ed25519 OpenSSH private key so every serialized public-key field points at
+ * [replacementAuthorizedKey], while the 32-byte private seed remains unchanged.
+ *
+ * OpenSSH stores the public key twice in this format: once as the top-level public key blob and
+ * once again inside the private-key section next to the seed. This helper rewrites both copies to
+ * the replacement key but preserves the original private seed bytes.
+ *
+ * The result is a deliberately inconsistent key file: the metadata says "this is key B" while the
+ * secret material still belongs to key A. `SshKey.parseIdentity()` should reject that mismatch.
+ */
+internal fun tamperEd25519PrivateKeyPublicParts(
+  privateKeyPem: String,
+  replacementAuthorizedKey: String,
+): String {
+  val replacementBlob = decodeAuthorizedKeyBlob(replacementAuthorizedKey)
+  val replacementPublicKey =
+    SshWireReader(replacementBlob).run {
+      readString() // type
+      readString()
+    }
+
+  val blob = decodeOpenSshPem(privateKeyPem)
+  val reader = SshWireReader(blob)
+  val magic = reader.readRaw(AUTH_MAGIC.size)
+  val cipherName = reader.readString()
+  val kdfName = reader.readString()
+  val kdfOptions = reader.readString()
+  val numKeys = reader.readUInt32()
+  reader.readString() // original public key blob
+  val privateSection = reader.readString()
+
+  val privateReader = SshWireReader(privateSection)
+  val check1 = privateReader.readUInt32()
+  val check2 = privateReader.readUInt32()
+  val keyType = privateReader.readString()
+  privateReader.readString() // original public key
+  val privateKeyBytes = privateReader.readString()
+  val comment = privateReader.readString()
+  val padding = privateReader.readRaw(privateReader.remaining())
+
+  val rewrittenPrivateSection =
+    ByteArrayOutputStream().apply {
+      writeUInt32(check1)
+      writeUInt32(check2)
+      writeSshString(keyType)
+      writeSshString(replacementPublicKey)
+      writeSshString(privateKeyBytes)
+      writeSshString(comment)
+      write(padding)
+    }
+
+  val rewrittenBlob =
+    ByteArrayOutputStream().apply {
+      write(magic)
+      writeSshString(cipherName)
+      writeSshString(kdfName)
+      writeSshString(kdfOptions)
+      writeUInt32(numKeys)
+      writeSshString(replacementBlob)
+      writeSshString(rewrittenPrivateSection.toByteArray())
+    }
+
+  return encodeOpenSshPem(rewrittenBlob.toByteArray())
+}
+
+/**
+ * Rewrites only the top-level public-key blob of an RSA OpenSSH private key to use
+ * [replacementAuthorizedKey], leaving the serialized RSA private key parameters untouched.
+ *
+ * That creates a private key file whose fingerprinting/toplevel public metadata refers to one RSA
+ * key while the CRT parameters still describe another. `SshKey.parseIdentity()` should detect and
+ * reject this inconsistency instead of accepting the tampered file.
+ */
+internal fun tamperRsaPrivateKeyOuterPublicKey(
+  privateKeyPem: String,
+  replacementAuthorizedKey: String,
+): String {
+  val replacementBlob = decodeAuthorizedKeyBlob(replacementAuthorizedKey)
+
+  val blob = decodeOpenSshPem(privateKeyPem)
+  val reader = SshWireReader(blob)
+  val magic = reader.readRaw(AUTH_MAGIC.size)
+  val cipherName = reader.readString()
+  val kdfName = reader.readString()
+  val kdfOptions = reader.readString()
+  val numKeys = reader.readUInt32()
+  reader.readString() // original public key blob
+  val privateSection = reader.readString()
+
+  val rewrittenBlob =
+    ByteArrayOutputStream().apply {
+      write(magic)
+      writeSshString(cipherName)
+      writeSshString(kdfName)
+      writeSshString(kdfOptions)
+      writeUInt32(numKeys)
+      writeSshString(replacementBlob)
+      writeSshString(privateSection)
+    }
+
+  return encodeOpenSshPem(rewrittenBlob.toByteArray())
+}
+
+internal fun encodeOpenSshPem(blob: ByteArray): String {
+  val body = Base64.getMimeEncoder(64, "\n".toByteArray()).encodeToString(blob)
+  return "-----BEGIN OPENSSH PRIVATE KEY-----\n$body\n-----END OPENSSH PRIVATE KEY-----"
+}
+
+private fun decodeOpenSshPem(pem: String): ByteArray {
+  val begin = "-----BEGIN OPENSSH PRIVATE KEY-----"
+  val end = "-----END OPENSSH PRIVATE KEY-----"
+  val body = pem.substringAfter(begin).substringBefore(end).replace(Regex("\\s"), "")
+  return Base64.getDecoder().decode(body)
+}
+
+private fun decodeAuthorizedKeyBlob(authorizedKey: String): ByteArray {
+  val fields = authorizedKey.trim().split(Regex("\\s+"))
+  return Base64.getDecoder().decode(fields[1])
+}
+
+private fun ByteArrayOutputStream.writeUInt32(value: Long) {
+  write(
+    byteArrayOf(
+      ((value ushr 24) and 0xff).toByte(),
+      ((value ushr 16) and 0xff).toByte(),
+      ((value ushr 8) and 0xff).toByte(),
+      (value and 0xff).toByte(),
+    )
+  )
+}
+
+private fun ByteArrayOutputStream.writeSshString(value: ByteArray) {
+  writeUInt32(value.size.toLong())
+  write(value)
+}
+
+private val AUTH_MAGIC = "openssh-key-v1".toByteArray(Charsets.US_ASCII).plus(0x00.toByte())


### PR DESCRIPTION
kage has X25519 and scrypt recipients but no SSH key support. age and rage both let you encrypt to an SSH public key you already have (`age -R ~/.ssh/id_ed25519.pub`) and decrypt with the private key. This adds `ssh-ed25519` and `ssh-rsa`. I want it for an Android app I'm building on kage, so people can use the SSH keys they already have instead of generating a new age identity.

`SshKey.parseRecipient` reads an `authorized_keys`-style public line and `SshKey.parseIdentity` reads an unencrypted OpenSSH private key. For ssh-ed25519 the key is converted to its Curve25519 form and goes through the same X25519 agreement and per-key HKDF tweak age uses. For ssh-rsa the file key is wrapped with RSA-OAEP using SHA-256, MGF1-SHA256, and the label `age-encryption.org/v1/ssh-rsa`. Both produce stanzas that interoperate with age in either direction.

The RSA path uses the BouncyCastle lightweight API (`OAEPEncoding`) instead of a JCA `Cipher`. This matters on Android: Conscrypt silently ignores the MGF1 digest in `OAEPParameterSpec` and falls back to MGF1-SHA1, so the ciphertext won't decrypt under age. The lightweight API keeps MGF1 on SHA-256 everywhere, and it's also how kage already does ChaCha20-Poly1305, X25519, scrypt, and HKDF. Keys under 2048 bits are rejected, like age and OpenSSH.

A few things are intentionally out of scope for now. Only the `none` cipher is read, so passphrase-encrypted private keys aren't supported, and multi-key OpenSSH files are rejected. Both throw `UnsupportedSshKeyException`.

The tests include files generated by age for each key type and decrypted here. That's the part that actually proves interop, since a kage-to-kage round-trip would pass even if both ends drifted from age together. There are also round-trip, recipient-from-identity, and malformed-input tests.

A couple of notes for review:

- This adds public API: `SshKey`, the four recipient/identity classes, and the `InvalidSshKeyException`/`UnsupportedSshKeyException`/`SshIdentityException` types. They show up in the `kage.api` diff. Happy to narrow the surface or rename if you'd rather.
- I verified locally with `./gradlew test checkKotlinAbi animalsnifferMain spotlessCheck`. I left pitest to CI since it forks a JVM per core and runs my machine out of memory.
