### PR TITLE
feat: expose and validate the scrypt recipient work factor

### DIFF
--- a/api/kage.api
+++ b/api/kage.api
@@ -30,11 +30,16 @@ public final class kage/crypto/scrypt/ScryptIdentity : kage/Identity {
 }
 
 public final class kage/crypto/scrypt/ScryptRecipient : kage/Recipient, kage/RecipientWithLabels {
+	public static final field Companion Lkage/crypto/scrypt/ScryptRecipient$Companion;
+	public static final field DEFAULT_WORK_FACTOR I
 	public fun <init> ([B)V
 	public fun <init> ([BI)V
 	public synthetic fun <init> ([BIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun wrap ([B)Ljava/util/List;
 	public fun wrapWithLabels ([B)Lkotlin/Pair;
+}
+
+public final class kage/crypto/scrypt/ScryptRecipient$Companion {
 }
 
 public final class kage/crypto/x25519/X25519 {

--- a/src/kotlin/kage/crypto/scrypt/ScryptIdentity.kt
+++ b/src/kotlin/kage/crypto/scrypt/ScryptIdentity.kt
@@ -18,8 +18,10 @@ import org.bouncycastle.crypto.generators.SCrypt
 
 public class ScryptIdentity
 @JvmOverloads
-constructor(private val password: ByteArray, private val maxWorkFactor: Int = DEFAULT_WORK_FACTOR) :
-  Identity {
+constructor(
+  private val password: ByteArray,
+  private val maxWorkFactor: Int = DEFAULT_MAX_WORK_FACTOR,
+) : Identity {
 
   init {
     require(maxWorkFactor in 2..30) { "workFactor must be > 1 and <= 30" }
@@ -65,6 +67,8 @@ constructor(private val password: ByteArray, private val maxWorkFactor: Int = DE
   }
 
   private companion object {
-    const val DEFAULT_WORK_FACTOR = 22
+    // Ceiling on the work factor accepted when decrypting, bounding the scrypt cost a hostile file
+    // can force. Distinct from the encrypt-side ScryptRecipient.DEFAULT_WORK_FACTOR.
+    const val DEFAULT_MAX_WORK_FACTOR = 22
   }
 }

--- a/src/kotlin/kage/crypto/scrypt/ScryptRecipient.kt
+++ b/src/kotlin/kage/crypto/scrypt/ScryptRecipient.kt
@@ -45,10 +45,16 @@ constructor(private val password: ByteArray, private val workFactor: Int = DEFAU
     return Pair(stanzas, listOf(label.encodeBase64()))
   }
 
-  internal companion object {
-    const val SCRYPT_SALT_SIZE = 16
-    const val SCRYPT_STANZA_TYPE = "scrypt"
-    const val SCRYPT_SALT_LABEL = "age-encryption.org/v1/scrypt"
-    const val DEFAULT_WORK_FACTOR = 18
+  public companion object {
+    /**
+     * The default scrypt work factor: the base-2 logarithm of the CPU/memory cost parameter N, used
+     * when a work factor is not supplied to the constructor. Exposed so callers can reference the
+     * value kage applies by default, e.g. to surface it in a UI or to derive a relative one.
+     */
+    public const val DEFAULT_WORK_FACTOR: Int = 18
+
+    internal const val SCRYPT_SALT_SIZE = 16
+    internal const val SCRYPT_STANZA_TYPE = "scrypt"
+    internal const val SCRYPT_SALT_LABEL = "age-encryption.org/v1/scrypt"
   }
 }

--- a/src/kotlin/kage/crypto/scrypt/ScryptRecipient.kt
+++ b/src/kotlin/kage/crypto/scrypt/ScryptRecipient.kt
@@ -19,6 +19,12 @@ public class ScryptRecipient
 constructor(private val password: ByteArray, private val workFactor: Int = DEFAULT_WORK_FACTOR) :
   Recipient, RecipientWithLabels {
 
+  init {
+    // wrap() computes `1 shl workFactor`, whose shift is masked to 5 bits, so >= 31 silently wraps
+    // to a weak N. Bound it to the range ScryptIdentity accepts on decrypt.
+    require(workFactor in 1..30) { "workFactor must be in 1..30, was $workFactor" }
+  }
+
   override fun wrap(fileKey: ByteArray): List<AgeStanza> {
     val salt = ByteArray(SCRYPT_SALT_SIZE)
     SecureRandom().nextBytes(salt)

--- a/src/test/kotlin/kage/crypto/scrypt/ScryptRecipientTest.kt
+++ b/src/test/kotlin/kage/crypto/scrypt/ScryptRecipientTest.kt
@@ -9,8 +9,22 @@ import com.google.common.truth.Truth.assertThat
 import java.security.SecureRandom
 import kage.Age
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class ScryptRecipientTest {
+  @Test
+  fun testRejectsOutOfRangeWorkFactor() {
+    // Below the lower bound, plus values where `1 shl workFactor` overflows or wraps (31, 33).
+    for (bad in listOf(Int.MIN_VALUE, -1, 0, 31, 32, 33, Int.MAX_VALUE)) {
+      assertThrows<IllegalArgumentException>("workFactor=$bad should be rejected") {
+        ScryptRecipient("mypass".toByteArray(), workFactor = bad)
+      }
+    }
+    // The valid bounds construct without throwing.
+    ScryptRecipient("mypass".toByteArray(), workFactor = 1)
+    ScryptRecipient("mypass".toByteArray(), workFactor = 30)
+  }
+
   @Test
   fun testWrapUnwrap() {
     val recipient = ScryptRecipient("mypass".toByteArray(), workFactor = 1)


### PR DESCRIPTION
Two small changes to `ScryptRecipient`, both from building on kage.

The default scrypt work factor was hardcoded as `18` inside `wrap()`. This pulls it out into a public `ScryptRecipient.DEFAULT_WORK_FACTOR` so callers can read or display the value kage uses instead of repeating the literal.

The recipient also never checked the work factor it was handed. `wrap()` does `1 shl workFactor`, and an `Int` shift on the JVM masks the count to 5 bits, so `workFactor = 33` quietly becomes `1 shl 1`, which is `2`, and `31` or `32` give a negative or zero `N`. You end up with a file encrypted at near-zero scrypt cost and no error. I added `require(workFactor in 1..30)` in an `init` block, the same range `ScryptIdentity` already enforces on the decrypt side. I also renamed the private decrypt-side constant from `DEFAULT_WORK_FACTOR` to `DEFAULT_MAX_WORK_FACTOR`, since it's the ceiling accepted when decrypting and read confusingly next to the new encrypt-side default.

The test checks that `Int.MIN_VALUE, -1, 0, 31, 32, 33, Int.MAX_VALUE` are rejected and that `1` and `30` still construct.

Notes for review:

- The new `DEFAULT_WORK_FACTOR` constant is in the `kage.api` diff. The rename is private and doesn't touch the surface.
- Verified with `./gradlew test checkKotlinAbi animalsnifferMain spotlessCheck`; pitest left to CI.
