### PR TITLE
fix(stream): read the full chunk before treating it as the last

### DIFF
--- a/src/kotlin/kage/crypto/stream/DecryptInputStream.kt
+++ b/src/kotlin/kage/crypto/stream/DecryptInputStream.kt
@@ -68,10 +68,10 @@ internal class DecryptInputStream(private val key: ByteArray, private val input:
 
     var last = false
 
-    val read = input.read(buf, 0, buf.size)
+    val read = readFull(buf)
     bufSize = read
 
-    if (read == -1) throw StreamException("Unexpected EOF. File ended without a marked chunk")
+    if (read == 0) throw StreamException("Unexpected EOF. File ended without a marked chunk")
 
     if (read != buf.size) { // Incomplete chunk
       if (
@@ -106,5 +106,26 @@ internal class DecryptInputStream(private val key: ByteArray, private val input:
     incNonce(this.nonce)
 
     return last
+  }
+
+  /**
+   * Fill [dst] completely, looping until it is full or the stream is genuinely exhausted, and
+   * return the number of bytes read (0 only at immediate EOF).
+   *
+   * [InputStream.read] may return fewer bytes than requested even when the stream is not at EOF —
+   * this is common for file, SAF (`content://`) and buffered streams. The chunk reader treats a
+   * short read as the final chunk, so without reading fully a mid-stream short read is mistaken for
+   * the last chunk and ChaCha20-Poly1305 authentication fails ("error occurred while decrypting
+   * stream") on any payload larger than a single chunk. A ByteArrayInputStream always fills the
+   * buffer, which is why in-memory round-trips did not surface this.
+   */
+  private fun readFull(dst: ByteArray): Int {
+    var offset = 0
+    while (offset < dst.size) {
+      val n = input.read(dst, offset, dst.size - offset)
+      if (n == -1) break // genuine EOF
+      offset += n
+    }
+    return offset
   }
 }

--- a/src/test/kotlin/kage/crypto/stream/DecryptInputStreamTest.kt
+++ b/src/test/kotlin/kage/crypto/stream/DecryptInputStreamTest.kt
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.stream
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.security.SecureRandom
+import org.junit.jupiter.api.Test
+
+class DecryptInputStreamTest {
+  /**
+   * Wraps an [InputStream] and never returns more than one byte per buffered [read] call, so
+   * callers that assume a single call fills the requested buffer are exercised the same way a file,
+   * SAF (`content://`), or buffered stream would break them.
+   */
+  private class ShortReadInputStream(private val delegate: InputStream) : InputStream() {
+    override fun read(): Int = delegate.read()
+
+    override fun read(b: ByteArray, off: Int, len: Int): Int {
+      if (len == 0) return 0
+      val next = delegate.read()
+      if (next == -1) return -1
+      b[off] = next.toByte()
+      return 1
+    }
+  }
+
+  @Test
+  fun readChunkSurvivesShortReads() {
+    val key = ByteArray(ChaCha20Poly1305.KEY_LENGTH)
+    SecureRandom().nextBytes(key)
+
+    // Larger than a single chunk so readChunk's buffer fill runs more than once.
+    val payload = ByteArray(EncryptOutputStream.CHUNK_SIZE + 137)
+    SecureRandom().nextBytes(payload)
+
+    val ciphertext = ByteArrayOutputStream()
+    EncryptOutputStream(key, ciphertext).use { it.write(payload) }
+
+    // InputStream.read(buf, off, len) is allowed to return fewer bytes than requested even
+    // mid-stream (file, SAF and buffered streams all do this); ByteArrayInputStream always fills
+    // the buffer in one call, which is why a short read being mistaken for the last chunk never
+    // surfaced here. Force the worst case: never more than 1 byte per call.
+    val input = ShortReadInputStream(ByteArrayInputStream(ciphertext.toByteArray()))
+    val decrypted = DecryptInputStream(key, input).readAllBytes()
+
+    assertThat(decrypted).asList().containsExactlyElementsIn(payload.asList())
+  }
+}


### PR DESCRIPTION
DecryptInputStream.readChunk relied on a single InputStream.read() call filling the entire chunk buffer, but read() may return fewer bytes than requested mid-stream — file, SAF (content://) and buffered streams all do this routinely. A short read was mistaken for the final chunk (last-chunk flag set), so ChaCha20-Poly1305 authentication failed with "error occurred while decrypting stream" on any payload larger than one 64 KiB chunk. ByteArrayInputStream always fills the buffer in one call, which is why in-memory round-trips never surfaced it.

Replaced the single read() call with a readFull() helper that loops until the buffer is full or the stream is genuinely at EOF, so a mid-stream short read no longer gets mistaken for the last chunk.

Notes for review:

- Confirmed the bug is still present on current main: readChunk() still does a single input.read(buf, 0, buf.size) with no loop.
- This is separate from #539 (streaming vs. buffering the payload) — that PR didn't touch the short-read handling.
- Verified with ./gradlew test checkKotlinAbi animalsnifferMain spotlessCheck.