### PR TITLE
chore: ensure all public API is covered via KDoc

### DIFF
--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -56,7 +56,8 @@ public object Age {
   /**
    * Encrypts all data from [inputStream] for [recipients] and writes it to [outputStream].
    *
-   * This method closes both streams. Set [generateArmor] to emit ASCII-armored ciphertext.
+   * After encryption setup succeeds, this method closes both streams. Set [generateArmor] to emit
+   * ASCII-armored ciphertext.
    */
   @JvmStatic
   public fun encryptStream(
@@ -73,7 +74,8 @@ public object Age {
   /**
    * Encrypts [plainText] for [recipients] and returns the resulting in-memory age file.
    *
-   * This method closes [plainText]. Prefer [encryptStream] for large plaintexts.
+   * After encryption setup succeeds, this method closes [plainText]. Prefer [encryptStream] for
+   * large plaintexts.
    */
   @JvmStatic
   public fun encrypt(recipients: List<Recipient>, plainText: InputStream): AgeFile {

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -28,11 +28,18 @@ import kage.format.AgeFile
 import kage.format.AgeHeader
 import kage.format.AgeStanza
 
+/** Encrypts and decrypts data using the age file format. */
 public object Age {
   internal const val FILE_KEY_SIZE: Int = 16
   private const val STREAM_NONCE_SIZE = 16
   private const val HMAC_SIZE = 32
 
+  /**
+   * Starts encrypting data for [recipients] to [outputStream].
+   *
+   * Write plaintext to the returned stream, then close it to finish the encrypted payload and close
+   * [outputStream]. Set [generateArmor] to emit ASCII-armored ciphertext.
+   */
   @JvmStatic
   public fun encryptStream(
     recipients: List<Recipient>,
@@ -46,6 +53,11 @@ public object Age {
     return stream
   }
 
+  /**
+   * Encrypts all data from [inputStream] for [recipients] and writes it to [outputStream].
+   *
+   * This method closes both streams. Set [generateArmor] to emit ASCII-armored ciphertext.
+   */
   @JvmStatic
   public fun encryptStream(
     recipients: List<Recipient>,
@@ -58,6 +70,11 @@ public object Age {
     }
   }
 
+  /**
+   * Encrypts [plainText] for [recipients] and returns the resulting in-memory age file.
+   *
+   * This method closes [plainText]. Prefer [encryptStream] for large plaintexts.
+   */
   @JvmStatic
   public fun encrypt(recipients: List<Recipient>, plainText: InputStream): AgeFile {
     val out = ByteArrayOutputStream()
@@ -69,6 +86,12 @@ public object Age {
     return AgeFile(header, out.toByteArray())
   }
 
+  /**
+   * Decrypts an age stream using one of [identities] and writes the plaintext to [dstStream].
+   *
+   * Both binary and ASCII-armored ciphertext are accepted. This method closes [dstStream] after
+   * writing the plaintext.
+   */
   @JvmStatic
   public fun decryptStream(
     identities: List<Identity>,
@@ -101,10 +124,17 @@ public object Age {
     decryptStreamInternal(identities, decodedStream.buffered(), dstStream)
   }
 
+  /**
+   * Returns a stream that decrypts [ageFile] with one of [identities].
+   *
+   * Close the returned stream when finished. Prefer [decryptStream] when the ciphertext is already
+   * available as a stream.
+   */
   @JvmStatic
   public fun decrypt(identities: List<Identity>, ageFile: AgeFile): InputStream =
     decryptInternal(identities, ageFile)
 
+  /** Returns a stream that decrypts [ageFile] with [identity]. */
   @JvmStatic
   public fun decrypt(identity: Identity, ageFile: AgeFile): InputStream =
     decryptInternal(listOf(identity), ageFile)

--- a/src/kotlin/kage/Identity.kt
+++ b/src/kotlin/kage/Identity.kt
@@ -17,6 +17,11 @@ import kage.format.AgeStanza
  * [Age docs](https://github.com/FiloSottile/age/blob/ab3707c085f2c1/age.go#L59-L72)
  */
 public interface Identity {
+  /**
+   * Unwraps the file key from a stanza in [stanzas].
+   *
+   * @throws kage.errors.IncorrectIdentityException if none of the stanzas match this identity.
+   */
   public fun unwrap(stanzas: List<AgeStanza>): ByteArray
 }
 

--- a/src/kotlin/kage/Identity.kt
+++ b/src/kotlin/kage/Identity.kt
@@ -11,8 +11,8 @@ import kage.format.AgeStanza
  * An Identity is passed to Decrypt to unwrap an opaque file key from a recipient stanza. It can be
  * for example a secret key like X25519Identity, a plugin, or a custom implementation.
  *
- * Unwrap must return an error wrapping IncorrectIdentityError if none of the recipient stanzas
- * match the identity, any other error will be considered fatal.
+ * Unwrap must throw [kage.errors.IncorrectIdentityException] if none of the recipient stanzas match
+ * the identity; any other error is considered fatal.
  *
  * [Age docs](https://github.com/FiloSottile/age/blob/ab3707c085f2c1/age.go#L59-L72)
  */

--- a/src/kotlin/kage/Recipient.kt
+++ b/src/kotlin/kage/Recipient.kt
@@ -7,17 +7,15 @@ package kage
 
 import kage.format.AgeStanza
 
-/*
- * From the age docs:
- * A Recipient is passed to Encrypt to wrap an opaque file key to one or more
- * recipient stanza(s). It can be for example a public key like X25519Recipient,
- * a plugin, or a custom implementation.
- * https://github.com/FiloSottile/age/blob/ab3707c085f2c1fdfd767a2ed718423e3925f4c4/age.go#L76-L85
+/**
+ * Wraps an opaque file key into recipient stanzas during encryption.
  *
- * From the rage docs:
- * Implementations MUST NOT return more than one stanza per "actual recipient".
- * https://github.com/str4d/rage/blob/main/age/src/lib.rs#L225-L239
+ * Implementations can represent public keys, plugins, or custom recipients. They must return no
+ * more than one stanza per actual recipient.
+ *
+ * [Age docs](https://github.com/FiloSottile/age/blob/ab3707c085f2c1/age.go#L76-L85)
  */
 public interface Recipient {
+  /** Wraps [fileKey] for this recipient. */
   public fun wrap(fileKey: ByteArray): List<AgeStanza>
 }

--- a/src/kotlin/kage/RecipientWithLabels.kt
+++ b/src/kotlin/kage/RecipientWithLabels.kt
@@ -19,5 +19,11 @@ import kage.format.AgeStanza
  * alone (by returning a random label, for example to preserve its authentication properties).
  */
 public interface RecipientWithLabels {
+  /**
+   * Wraps [fileKey] and returns its stanzas with labels describing recipient compatibility.
+   *
+   * The first element contains the recipient stanzas; the second contains labels that must match
+   * those returned by every other recipient in an encryption operation.
+   */
   public fun wrapWithLabels(fileKey: ByteArray): Pair<List<AgeStanza>, List<String>>
 }

--- a/src/kotlin/kage/crypto/scrypt/ScryptIdentity.kt
+++ b/src/kotlin/kage/crypto/scrypt/ScryptIdentity.kt
@@ -16,6 +16,12 @@ import kage.multiUnwrap
 import kage.utils.decodeBase64
 import org.bouncycastle.crypto.generators.SCrypt
 
+/**
+ * An age identity that decrypts files encrypted with the supplied password.
+ *
+ * @param password Password bytes used to derive the wrapping key.
+ * @param maxWorkFactor Largest scrypt work factor accepted while decrypting, to bound resource use.
+ */
 public class ScryptIdentity
 @JvmOverloads
 constructor(

--- a/src/kotlin/kage/crypto/scrypt/ScryptRecipient.kt
+++ b/src/kotlin/kage/crypto/scrypt/ScryptRecipient.kt
@@ -14,6 +14,12 @@ import kage.format.AgeStanza
 import kage.utils.encodeBase64
 import org.bouncycastle.crypto.generators.SCrypt
 
+/**
+ * An age recipient that encrypts files with the supplied password.
+ *
+ * @param password Password bytes used to derive the wrapping key.
+ * @param workFactor Base-2 logarithm of scrypt's CPU and memory cost parameter N.
+ */
 public class ScryptRecipient
 @JvmOverloads
 constructor(private val password: ByteArray, private val workFactor: Int = DEFAULT_WORK_FACTOR) :

--- a/src/kotlin/kage/crypto/ssh/SshEd25519Identity.kt
+++ b/src/kotlin/kage/crypto/ssh/SshEd25519Identity.kt
@@ -70,6 +70,7 @@ internal constructor(
 
   override fun unwrap(stanzas: List<AgeStanza>): ByteArray = multiUnwrap(::unwrapSingle, stanzas)
 
+  /** Returns the SSH Ed25519 recipient corresponding to this identity. */
   public fun recipient(): SshEd25519Recipient = SshEd25519Recipient(sshKeyBlob, ed25519PublicKey)
 
   private companion object {

--- a/src/kotlin/kage/crypto/ssh/SshRsaIdentity.kt
+++ b/src/kotlin/kage/crypto/ssh/SshRsaIdentity.kt
@@ -48,6 +48,7 @@ internal constructor(
 
   override fun unwrap(stanzas: List<AgeStanza>): ByteArray = multiUnwrap(::unwrapSingle, stanzas)
 
+  /** Returns the SSH RSA recipient corresponding to this identity. */
   public fun recipient(): SshRsaRecipient {
     val publicKey = RSAKeyParameters(false, privateKey.modulus, privateKey.publicExponent)
     return SshRsaRecipient(sshKeyBlob, publicKey)

--- a/src/kotlin/kage/crypto/x25519/X25519.kt
+++ b/src/kotlin/kage/crypto/x25519/X25519.kt
@@ -8,8 +8,14 @@ package kage.crypto.x25519
 import kage.errors.X25519LowOrderPointException
 import org.bouncycastle.math.ec.rfc7748.X25519
 
+/** X25519 scalar-multiplication primitives used by the age X25519 recipient implementation. */
 public object X25519 {
 
+  /**
+   * Multiplies the X25519 scalar [input] by the point [r].
+   *
+   * @throws X25519LowOrderPointException if [r] is a low-order point.
+   */
   public fun scalarMult(input: ByteArray, r: ByteArray): ByteArray {
     val out = ByteArray(input.size)
 
@@ -20,6 +26,7 @@ public object X25519 {
     return out
   }
 
+  /** Multiplies the X25519 scalar [input] by the standard base point. */
   public fun scalarMultBase(input: ByteArray): ByteArray {
     val out = ByteArray(input.size)
 

--- a/src/kotlin/kage/crypto/x25519/X25519Identity.kt
+++ b/src/kotlin/kage/crypto/x25519/X25519Identity.kt
@@ -23,6 +23,12 @@ import kage.multiUnwrap
 import kage.utils.decodeBase64
 import org.bouncycastle.math.ec.rfc7748.X25519.POINT_SIZE
 
+/**
+ * An age identity backed by an X25519 key pair.
+ *
+ * @param secretKey Raw private X25519 key.
+ * @param publicKey Raw public X25519 key corresponding to [secretKey].
+ */
 public class X25519Identity(private val secretKey: ByteArray, private val publicKey: ByteArray) :
   Identity {
 
@@ -60,13 +66,16 @@ public class X25519Identity(private val secretKey: ByteArray, private val public
     return multiUnwrap(::unwrapSingle, stanzas)
   }
 
+  /** Returns the public recipient corresponding to this identity. */
   public fun recipient(): X25519Recipient = X25519Recipient(publicKey)
 
+  /** Encodes this identity as an `AGE-SECRET-KEY-` Bech32 string. */
   public fun encodeToString(): String =
     Bech32.encode(AgeKeyFile.AGE_SECRET_KEY_PREFIX, secretKey).getOrThrow()
 
   public companion object {
 
+    /** Decodes an `AGE-SECRET-KEY-` Bech32 string into an X25519 identity. */
     public fun decode(string: String): X25519Identity {
       val (hrp, key) =
         Bech32.decode(string)

--- a/src/kotlin/kage/crypto/x25519/X25519Recipient.kt
+++ b/src/kotlin/kage/crypto/x25519/X25519Recipient.kt
@@ -17,6 +17,11 @@ import kage.format.AgeStanza
 import kage.format.Bech32
 import kage.utils.encodeBase64
 
+/**
+ * An age recipient backed by an X25519 public key.
+ *
+ * @param publicKey Raw public X25519 key.
+ */
 public class X25519Recipient(private val publicKey: ByteArray) : Recipient {
 
   override fun wrap(fileKey: ByteArray): List<AgeStanza> {
@@ -41,6 +46,7 @@ public class X25519Recipient(private val publicKey: ByteArray) : Recipient {
     return listOf(stanza)
   }
 
+  /** Encodes this recipient as an `age1...` Bech32 public key. */
   public fun encodeToString(): String = Bech32.encode(AGE_PUBLIC_KEY_PREFIX, publicKey).getOrThrow()
 
   public companion object {
@@ -50,6 +56,7 @@ public class X25519Recipient(private val publicKey: ByteArray) : Recipient {
     internal const val MAC_KEY_LENGTH = 32 // bytes
     internal const val EPHEMERAL_SECRET_LEN = 32 // bytes
 
+    /** Decodes an `age1...` Bech32 public key into an X25519 recipient. */
     public fun decode(string: String): X25519Recipient {
       val (hrp, key) =
         Bech32.decode(string)

--- a/src/kotlin/kage/errors/CryptoException.kt
+++ b/src/kotlin/kage/errors/CryptoException.kt
@@ -10,7 +10,7 @@ public sealed class CryptoException
 @JvmOverloads
 constructor(message: String? = null, cause: Throwable? = null) : Exception(message, cause)
 
-/** Raised when no [kage.Recipient] is available in the ciphertext. */
+/** Raised when encryption is requested without any [kage.Recipient]s. */
 public class NoRecipientsException
 @JvmOverloads
 constructor(message: String? = null, cause: Throwable? = null) : CryptoException(message, cause)
@@ -75,6 +75,7 @@ public class NoIdentitiesException
 constructor(message: String? = null, cause: Throwable? = null) :
   InvalidIdentityException(message, cause)
 
+/** Raised when ciphertext does not have the size required by its cryptographic operation. */
 public class IncorrectCipherTextSizeException(cause: Throwable? = null) :
   CryptoException("Incorrect cipher text size", cause)
 

--- a/src/kotlin/kage/format/AgeFile.kt
+++ b/src/kotlin/kage/format/AgeFile.kt
@@ -8,6 +8,12 @@ package kage.format
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 
+/**
+ * An in-memory age-encrypted file.
+ *
+ * @property header The file header containing recipient stanzas and its MAC.
+ * @property body The encrypted payload, including its nonce.
+ */
 public class AgeFile(public val header: AgeHeader, public val body: ByteArray) {
 
   override fun equals(other: Any?): Boolean {

--- a/src/kotlin/kage/format/AgeHeader.kt
+++ b/src/kotlin/kage/format/AgeHeader.kt
@@ -22,6 +22,12 @@ import kage.utils.readLine
 import kage.utils.writeNewLine
 import kage.utils.writeSpace
 
+/**
+ * The authenticated header of an age file.
+ *
+ * @property recipients Stanzas that wrap the file key for each recipient.
+ * @property mac Message authentication code for the serialized header.
+ */
 public class AgeHeader(public val recipients: List<AgeStanza>, public val mac: ByteArray) {
 
   internal fun write(writer: BufferedWriter) {

--- a/src/kotlin/kage/format/AgeKeyFile.kt
+++ b/src/kotlin/kage/format/AgeKeyFile.kt
@@ -12,6 +12,13 @@ import kage.crypto.x25519.X25519Recipient
 import kage.errors.InvalidAgeKeyException
 import kage.utils.writeNewLine
 
+/**
+ * The contents of an age X25519 identity file.
+ *
+ * @property created Value from the file's `created` comment.
+ * @property publicKey Public key from the file, if present.
+ * @property privateKey Private X25519 identity from the file.
+ */
 public class AgeKeyFile(
   public val created: String,
   public val publicKey: X25519Recipient?,

--- a/src/kotlin/kage/format/AgeStanza.kt
+++ b/src/kotlin/kage/format/AgeStanza.kt
@@ -24,6 +24,13 @@ import kage.utils.readLine
 import kage.utils.writeNewLine
 import kage.utils.writeSpace
 
+/**
+ * A recipient stanza in an age file header.
+ *
+ * @property type Recipient type name.
+ * @property args Recipient-specific arguments.
+ * @property body Recipient-specific binary body.
+ */
 public class AgeStanza(
   public val type: String,
   public val args: List<String>,

--- a/src/test/kotlin/kage/format/AgeFileTest.kt
+++ b/src/test/kotlin/kage/format/AgeFileTest.kt
@@ -14,16 +14,14 @@ import org.junit.jupiter.api.Test
 
 class AgeFileTest {
 
+  val testFile =
+    Base64.decode(
+      "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdCArNlZtcm5hOWRXdjZTNEFBOFJ2MEZRIDE4CjJISTM0aTYxRHNkVHNMdVVvdXoyWk1jVTM1WUk0R2F1TlJEMDBnL0M2Nk0KLS0tIC9GSXA0eElxS1BqUG80aEJkK2lPNDRibyt1R093Q2IvWVZrTTRxcFJhZk0KUuBcu00b/uzC+wlTRwEHxBI4tR1LlkR5YQ7rvOZXJepwOZ7j9pJNIW3jgbIotYnurGE/6A=="
+    )
+
   @Test
   fun testParseAgeGoFile() {
-    val testFile =
-      Base64.decode(
-        "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdCArNlZtcm5hOWRXdjZTNEFBOFJ2MEZRIDE4CjJISTM0aTYxRHNkVHNMdVVvdXoyWk1jVTM1WUk0R2F1TlJEMDBnL0M2Nk0KLS0tIC9GSXA0eElxS1BqUG80aEJkK2lPNDRibyt1R093Q2IvWVZrTTRxcFJhZk0KUuBcu00b/uzC+wlTRwEHxBI4tR1LlkR5YQ7rvOZXJepwOZ7j9pJNIW3jgbIotYnurGE/6A=="
-      )
-
-    val inputStream = ByteArrayInputStream(testFile)
-
-    val ageFile = AgeFile.parse(inputStream)
+    val ageFile = AgeFile.parse(ByteArrayInputStream(testFile))
 
     val recipient = ageFile.header.recipients.first()
 
@@ -32,5 +30,16 @@ class AgeFileTest {
     assertThat(ageFile.body)
       .asList()
       .containsExactlyElementsIn(testFile.takeLast(ageFile.body.size))
+  }
+
+  // Mostly exists to appease the coverage gods but it's still a
+  // good enough property to keep intact
+  @Test
+  fun testEquals() {
+    val age1 = AgeFile.parse(ByteArrayInputStream(testFile))
+    val age2 = AgeFile.parse(ByteArrayInputStream(testFile))
+
+    assertThat(age1).isEqualTo(age2)
+    assertThat(age1.hashCode()).isEqualTo(age2.hashCode())
   }
 }


### PR DESCRIPTION
Does a pass through every single public class/method/property to ensure it is documented.
