### PR TITLE
feat: add the MLKEM768-X25519 post-quantum recipient type

### DIFF
--- a/api/kage.api
+++ b/api/kage.api
@@ -365,3 +365,12 @@ public final class kage/format/AgeStanza {
 	public static final fun writeBody$kage (Ljava/io/BufferedWriter;[B)V
 }
 
+public final class kage/format/MlKem768X25519KeyFile {
+	public fun <init> (Ljava/lang/String;Lkage/crypto/mlkem/MlKem768X25519Recipient;Lkage/crypto/mlkem/MlKem768X25519Identity;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreated ()Ljava/lang/String;
+	public final fun getPrivateKey ()Lkage/crypto/mlkem/MlKem768X25519Identity;
+	public final fun getPublicKey ()Lkage/crypto/mlkem/MlKem768X25519Recipient;
+	public fun hashCode ()I
+}
+

--- a/api/kage.api
+++ b/api/kage.api
@@ -29,6 +29,31 @@ public abstract interface class kage/RecipientWithLabels {
 	public abstract fun wrapWithLabels ([B)Lkotlin/Pair;
 }
 
+public final class kage/crypto/mlkem/MlKem768X25519Identity : kage/Identity {
+	public static final field Companion Lkage/crypto/mlkem/MlKem768X25519Identity$Companion;
+	public fun <init> ([B)V
+	public final fun encodeToString ()Ljava/lang/String;
+	public final fun recipient ()Lkage/crypto/mlkem/MlKem768X25519Recipient;
+	public fun unwrap (Ljava/util/List;)[B
+}
+
+public final class kage/crypto/mlkem/MlKem768X25519Identity$Companion {
+	public final fun decode (Ljava/lang/String;)Lkage/crypto/mlkem/MlKem768X25519Identity;
+	public final fun new ()Lkage/crypto/mlkem/MlKem768X25519Identity;
+}
+
+public final class kage/crypto/mlkem/MlKem768X25519Recipient : kage/Recipient, kage/RecipientWithLabels {
+	public static final field Companion Lkage/crypto/mlkem/MlKem768X25519Recipient$Companion;
+	public fun <init> ([B)V
+	public final fun encodeToString ()Ljava/lang/String;
+	public fun wrap ([B)Ljava/util/List;
+	public fun wrapWithLabels ([B)Lkotlin/Pair;
+}
+
+public final class kage/crypto/mlkem/MlKem768X25519Recipient$Companion {
+	public final fun decode (Ljava/lang/String;)Lkage/crypto/mlkem/MlKem768X25519Recipient;
+}
+
 public final class kage/crypto/scrypt/ScryptIdentity : kage/Identity {
 	public fun <init> ([B)V
 	public fun <init> ([BI)V
@@ -227,6 +252,13 @@ public final class kage/errors/InvalidSshKeyException : kage/errors/CryptoExcept
 }
 
 public final class kage/errors/InvalidVersionException : kage/errors/ParseException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class kage/errors/MlKem768X25519IdentityException : kage/errors/InvalidIdentityException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -229,26 +229,29 @@ public object Age {
 
     val exceptions = mutableListOf<Exception>()
 
+    var fileKey: ByteArray? = null
+
     for (identity in identities) {
-      val fileKey =
-        try {
-          identity.unwrap(header.recipients)
-        } catch (err: IncorrectIdentityException) {
-          exceptions.add(err)
-          continue
-        }
-
-      if (header.mac.size != HMAC_SIZE) throw InvalidHMACHeaderException("invalid header mac")
-
-      val calculatedMac = Primitives.headerMAC(fileKey, header)
-
-      if (!MessageDigest.isEqual(header.mac, calculatedMac))
-        throw IncorrectHMACException("bad header MAC")
-
-      return fileKey
+      try {
+        val unwrappedFileKey = identity.unwrap(header.recipients)
+        if (fileKey == null) fileKey = unwrappedFileKey
+      } catch (err: IncorrectIdentityException) {
+        exceptions.add(err)
+      }
     }
 
-    throw exceptions.reduce { acc, exception -> acc.apply { addSuppressed(exception) } }
+    val resolvedFileKey =
+      fileKey
+        ?: throw exceptions.reduce { acc, exception -> acc.apply { addSuppressed(exception) } }
+
+    if (header.mac.size != HMAC_SIZE) throw InvalidHMACHeaderException("invalid header mac")
+
+    val calculatedMac = Primitives.headerMAC(resolvedFileKey, header)
+
+    if (!MessageDigest.isEqual(header.mac, calculatedMac))
+      throw IncorrectHMACException("bad header MAC")
+
+    return resolvedFileKey
   }
 
   // Wraps [srcStream] in an ArmorInputStream when it starts with an armor header, so that callers

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -18,6 +18,7 @@ import kage.crypto.stream.ArmorOutputStream
 import kage.crypto.stream.DecryptInputStream
 import kage.crypto.stream.EncryptOutputStream
 import kage.errors.IncorrectHMACException
+import kage.errors.IncorrectIdentityException
 import kage.errors.InvalidHMACHeaderException
 import kage.errors.InvalidNonceException
 import kage.errors.InvalidScryptRecipientException
@@ -232,7 +233,7 @@ public object Age {
       val fileKey =
         try {
           identity.unwrap(header.recipients)
-        } catch (err: Exception) {
+        } catch (err: IncorrectIdentityException) {
           exceptions.add(err)
           continue
         }

--- a/src/kotlin/kage/Identity.kt
+++ b/src/kotlin/kage/Identity.kt
@@ -5,6 +5,7 @@
  */
 package kage
 
+import kage.errors.IncorrectIdentityException
 import kage.format.AgeStanza
 
 /**
@@ -31,7 +32,7 @@ internal fun multiUnwrap(unwrapFn: (AgeStanza) -> ByteArray, stanzas: List<AgeSt
   stanzas.forEach { stanza ->
     try {
       return unwrapFn(stanza)
-    } catch (err: Exception) {
+    } catch (err: IncorrectIdentityException) {
       // will try next stanza
       exceptions.add(err)
     }

--- a/src/kotlin/kage/crypto/mlkem/Hpke.kt
+++ b/src/kotlin/kage/crypto/mlkem/Hpke.kt
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2026 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.mlkem
+
+import at.favre.lib.hkdf.HKDF
+import kage.crypto.stream.ChaCha20Poly1305
+
+/**
+ * RFC 9180 HPKE in base mode, restricted to the single cipher suite the age MLKEM768-X25519
+ * recipient type uses: MLKEM768-X25519 / HKDF-SHA256 / ChaCha20Poly1305.
+ *
+ * age seals exactly one message per stanza, so the sequence number is always zero and the base
+ * nonce is used as-is.
+ */
+internal object Hpke {
+  private const val VERSION_LABEL = "HPKE-v1"
+  private const val KEM_ID = 0x647a
+  private const val KDF_ID = 0x0001
+  private const val AEAD_ID = 0x0003
+  private const val MODE_BASE: Byte = 0x00
+
+  private val SUITE_ID =
+    "HPKE".toByteArray().plus(bigEndian(KEM_ID)).plus(bigEndian(KDF_ID)).plus(bigEndian(AEAD_ID))
+
+  fun seal(sharedSecret: ByteArray, info: ByteArray, plainText: ByteArray): ByteArray {
+    val (key, nonce) = keySchedule(sharedSecret, info)
+    return ChaCha20Poly1305.encrypt(key, nonce, plainText, 0, plainText.size)
+  }
+
+  fun open(sharedSecret: ByteArray, info: ByteArray, cipherText: ByteArray): ByteArray {
+    val (key, nonce) = keySchedule(sharedSecret, info)
+    val out = ByteArray(cipherText.size - ChaCha20Poly1305.MAC_SIZE)
+    ChaCha20Poly1305.decrypt(key, nonce, cipherText, 0, cipherText.size, out, 0)
+    return out
+  }
+
+  private fun keySchedule(sharedSecret: ByteArray, info: ByteArray): Pair<ByteArray, ByteArray> {
+    val pskIdHash = labeledExtract(null, "psk_id_hash", ByteArray(0))
+    val infoHash = labeledExtract(null, "info_hash", info)
+    val context = byteArrayOf(MODE_BASE).plus(pskIdHash).plus(infoHash)
+
+    val secret = labeledExtract(sharedSecret, "secret", ByteArray(0))
+
+    return Pair(
+      labeledExpand(secret, "key", context, ChaCha20Poly1305.KEY_LENGTH),
+      labeledExpand(secret, "base_nonce", context, ChaCha20Poly1305.NONCE_LENGTH),
+    )
+  }
+
+  private fun labeledExtract(salt: ByteArray?, label: String, ikm: ByteArray): ByteArray =
+    HKDF.fromHmacSha256()
+      .extract(salt, VERSION_LABEL.toByteArray().plus(SUITE_ID).plus(label.toByteArray()).plus(ikm))
+
+  private fun labeledExpand(
+    prk: ByteArray,
+    label: String,
+    info: ByteArray,
+    length: Int,
+  ): ByteArray =
+    HKDF.fromHmacSha256()
+      .expand(
+        prk,
+        bigEndian(length)
+          .plus(VERSION_LABEL.toByteArray())
+          .plus(SUITE_ID)
+          .plus(label.toByteArray())
+          .plus(info),
+        length,
+      )
+
+  private fun bigEndian(value: Int): ByteArray =
+    byteArrayOf((value ushr 8).toByte(), value.toByte())
+}

--- a/src/kotlin/kage/crypto/mlkem/MlKem768X25519.kt
+++ b/src/kotlin/kage/crypto/mlkem/MlKem768X25519.kt
@@ -9,6 +9,7 @@ import java.security.SecureRandom
 import kage.crypto.x25519.X25519
 import kage.errors.InvalidRecipientException
 import kage.errors.MlKem768X25519IdentityException
+import kage.errors.X25519LowOrderPointException
 import org.bouncycastle.crypto.digests.SHA3Digest
 import org.bouncycastle.crypto.digests.SHAKEDigest
 import org.bouncycastle.crypto.kems.MLKEMExtractor
@@ -70,6 +71,27 @@ internal object MlKem768X25519 {
 
   fun publicKey(privateKey: PrivateKey): ByteArray =
     privateKey.mlKem.publicKey.plus(privateKey.x25519PublicKey)
+
+  /** Rejects malformed ML-KEM and low-order X25519 public key components. */
+  fun validatePublicKey(publicKey: ByteArray) {
+    if (publicKey.size != PUBLIC_KEY_SIZE)
+      throw InvalidRecipientException("Invalid key size for age public key (${publicKey.size})")
+
+    try {
+      MLKEMPublicKeyParameters(
+        MLKEMParameters.ml_kem_768,
+        publicKey.copyOfRange(0, ENCAPSULATION_KEY_SIZE),
+      )
+      X25519.scalarMult(
+        ByteArray(POINT_SIZE),
+        publicKey.copyOfRange(ENCAPSULATION_KEY_SIZE, publicKey.size),
+      )
+    } catch (err: IllegalArgumentException) {
+      throw InvalidRecipientException("Invalid ML-KEM public key", err)
+    } catch (err: X25519LowOrderPointException) {
+      throw InvalidRecipientException("Invalid X25519 public key", err)
+    }
+  }
 
   /** Returns the shared secret and the encapsulated key for [publicKey]. */
   fun encapsulate(publicKey: ByteArray): Pair<ByteArray, ByteArray> {

--- a/src/kotlin/kage/crypto/mlkem/MlKem768X25519.kt
+++ b/src/kotlin/kage/crypto/mlkem/MlKem768X25519.kt
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2026 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.mlkem
+
+import java.security.SecureRandom
+import kage.crypto.x25519.X25519
+import kage.errors.InvalidRecipientException
+import kage.errors.MlKem768X25519IdentityException
+import org.bouncycastle.crypto.digests.SHA3Digest
+import org.bouncycastle.crypto.digests.SHAKEDigest
+import org.bouncycastle.crypto.kems.MLKEMExtractor
+import org.bouncycastle.crypto.kems.MLKEMGenerator
+import org.bouncycastle.crypto.params.MLKEMParameters
+import org.bouncycastle.crypto.params.MLKEMPrivateKeyParameters
+import org.bouncycastle.crypto.params.MLKEMPublicKeyParameters
+import org.bouncycastle.math.ec.rfc7748.X25519.POINT_SIZE
+
+/** The MLKEM768-X25519 (X-Wing) hybrid KEM used by the age post-quantum recipient type. */
+internal object MlKem768X25519 {
+  const val SEED_SIZE = 32 // bytes
+  const val ENCAPSULATION_KEY_SIZE = 1184 // bytes
+  const val CIPHER_TEXT_SIZE = 1088 // bytes
+  const val PUBLIC_KEY_SIZE = ENCAPSULATION_KEY_SIZE + POINT_SIZE
+  const val ENC_SIZE = CIPHER_TEXT_SIZE + POINT_SIZE
+
+  private const val ML_KEM_SEED_SIZE = 64 // bytes, FIPS 203 (d || z)
+
+  // The combiner label is the `\./` `/^\` ASCII art from filippo.io/hpke, spelled out as raw bytes
+  // so that no escaping is involved.
+  private val COMBINER_LABEL = byteArrayOf(0x5C, 0x2E, 0x2F, 0x2F, 0x5E, 0x5C)
+
+  /** An MLKEM768-X25519 private key expanded from a 32 byte identity seed. */
+  class PrivateKey(
+    val mlKem: MLKEMPrivateKeyParameters,
+    val x25519: ByteArray,
+    val x25519PublicKey: ByteArray,
+  )
+
+  /**
+   * Expands [seed] into an MLKEM768-X25519 private key.
+   *
+   * Both sub-keys are drawn from a single SHAKE256 stream keyed with [seed]: 64 bytes for the
+   * ML-KEM seed first, then 32 bytes for the X25519 scalar. X25519 accepts any 32 byte scalar, so
+   * the retry loop of the reference implementation is not needed here.
+   */
+  fun newPrivateKey(seed: ByteArray): PrivateKey {
+    if (seed.size != SEED_SIZE)
+      throw MlKem768X25519IdentityException(
+        "Invalid MLKEM768-X25519 private key size: (${seed.size})"
+      )
+
+    val shake = SHAKEDigest(256)
+    shake.update(seed, 0, seed.size)
+
+    val mlKemSeed = ByteArray(ML_KEM_SEED_SIZE)
+    shake.doOutput(mlKemSeed, 0, mlKemSeed.size)
+
+    val x25519Seed = ByteArray(POINT_SIZE)
+    shake.doOutput(x25519Seed, 0, x25519Seed.size)
+
+    return PrivateKey(
+      MLKEMPrivateKeyParameters(MLKEMParameters.ml_kem_768, mlKemSeed),
+      x25519Seed,
+      X25519.scalarMultBase(x25519Seed),
+    )
+  }
+
+  fun publicKey(privateKey: PrivateKey): ByteArray =
+    privateKey.mlKem.publicKey.plus(privateKey.x25519PublicKey)
+
+  /** Returns the shared secret and the encapsulated key for [publicKey]. */
+  fun encapsulate(publicKey: ByteArray): Pair<ByteArray, ByteArray> {
+    if (publicKey.size != PUBLIC_KEY_SIZE)
+      throw InvalidRecipientException("Invalid key size for age public key (${publicKey.size})")
+
+    val mlKemPublicKey =
+      MLKEMPublicKeyParameters(
+        MLKEMParameters.ml_kem_768,
+        publicKey.copyOfRange(0, ENCAPSULATION_KEY_SIZE),
+      )
+    val x25519PublicKey = publicKey.copyOfRange(ENCAPSULATION_KEY_SIZE, publicKey.size)
+
+    val encapsulated = MLKEMGenerator(SecureRandom()).generateEncapsulated(mlKemPublicKey)
+
+    val ephemeralSecret = ByteArray(POINT_SIZE)
+    SecureRandom().nextBytes(ephemeralSecret)
+
+    val ephemeralShare = X25519.scalarMultBase(ephemeralSecret)
+    val x25519Secret = X25519.scalarMult(ephemeralSecret, x25519PublicKey)
+
+    val sharedSecret =
+      sharedSecret(encapsulated.secret, x25519Secret, ephemeralShare, x25519PublicKey)
+
+    return Pair(sharedSecret, encapsulated.encapsulation.plus(ephemeralShare))
+  }
+
+  /** Returns the shared secret for the [ENC_SIZE] byte encapsulated key [enc]. */
+  fun decapsulate(privateKey: PrivateKey, enc: ByteArray): ByteArray {
+    val mlKemCipherText = enc.copyOfRange(0, CIPHER_TEXT_SIZE)
+    val ephemeralShare = enc.copyOfRange(CIPHER_TEXT_SIZE, enc.size)
+
+    val mlKemSecret = MLKEMExtractor(privateKey.mlKem).extractSecret(mlKemCipherText)
+    val x25519Secret = X25519.scalarMult(privateKey.x25519, ephemeralShare)
+
+    return sharedSecret(mlKemSecret, x25519Secret, ephemeralShare, privateKey.x25519PublicKey)
+  }
+
+  private fun sharedSecret(
+    mlKemSecret: ByteArray,
+    x25519Secret: ByteArray,
+    ephemeralShare: ByteArray,
+    x25519PublicKey: ByteArray,
+  ): ByteArray {
+    val digest = SHA3Digest(256)
+    digest.update(mlKemSecret, 0, mlKemSecret.size)
+    digest.update(x25519Secret, 0, x25519Secret.size)
+    digest.update(ephemeralShare, 0, ephemeralShare.size)
+    digest.update(x25519PublicKey, 0, x25519PublicKey.size)
+    digest.update(COMBINER_LABEL, 0, COMBINER_LABEL.size)
+
+    val out = ByteArray(digest.digestSize)
+    digest.doFinal(out, 0)
+    return out
+  }
+}

--- a/src/kotlin/kage/crypto/mlkem/MlKem768X25519Identity.kt
+++ b/src/kotlin/kage/crypto/mlkem/MlKem768X25519Identity.kt
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2026 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.mlkem
+
+import com.github.michaelbull.result.getOrThrow
+import com.github.michaelbull.result.mapError
+import java.security.SecureRandom
+import kage.Age
+import kage.Identity
+import kage.crypto.mlkem.MlKem768X25519Recipient.Companion.MLKEM768X25519_INFO
+import kage.crypto.mlkem.MlKem768X25519Recipient.Companion.MLKEM768X25519_STANZA_TYPE
+import kage.crypto.stream.ChaCha20Poly1305
+import kage.errors.IncorrectCipherTextSizeException
+import kage.errors.IncorrectIdentityException
+import kage.errors.MlKem768X25519IdentityException
+import kage.format.AgeStanza
+import kage.format.Bech32
+import kage.multiUnwrap
+import kage.utils.decodeBase64
+
+/**
+ * An age identity backed by an MLKEM768-X25519 (X-Wing) key pair.
+ *
+ * @param secretKey Raw 32 byte seed the key pair is derived from.
+ */
+public class MlKem768X25519Identity(private val secretKey: ByteArray) : Identity {
+
+  private val privateKey = MlKem768X25519.newPrivateKey(secretKey)
+
+  private fun unwrapSingle(stanza: AgeStanza): ByteArray {
+    if (stanza.type != MLKEM768X25519_STANZA_TYPE) throw IncorrectIdentityException()
+
+    if (stanza.args.size != 1)
+      throw MlKem768X25519IdentityException("invalid mlkem768x25519 recipient block")
+
+    val enc =
+      try {
+        stanza.args[0].decodeBase64()
+      } catch (err: Exception) {
+        throw MlKem768X25519IdentityException("invalid mlkem768x25519 recipient block", err)
+      }
+
+    if (enc.size != MlKem768X25519.ENC_SIZE)
+      throw MlKem768X25519IdentityException("invalid mlkem768x25519 recipient block")
+
+    // Checked before decrypting to mitigate partitioning oracle attacks.
+    if (stanza.body.size != Age.FILE_KEY_SIZE + ChaCha20Poly1305.MAC_SIZE)
+      throw IncorrectCipherTextSizeException()
+
+    val sharedSecret = MlKem768X25519.decapsulate(privateKey, enc)
+
+    try {
+      return Hpke.open(sharedSecret, MLKEM768X25519_INFO.toByteArray(), stanza.body)
+    } catch (err: Exception) {
+      throw IncorrectIdentityException(err)
+    }
+  }
+
+  override fun unwrap(stanzas: List<AgeStanza>): ByteArray {
+    return multiUnwrap(::unwrapSingle, stanzas)
+  }
+
+  /** Returns the public recipient corresponding to this identity. */
+  public fun recipient(): MlKem768X25519Recipient =
+    MlKem768X25519Recipient(MlKem768X25519.publicKey(privateKey))
+
+  /** Encodes this identity as an `AGE-SECRET-KEY-PQ-` Bech32 string. */
+  public fun encodeToString(): String =
+    Bech32.encode(AGE_SECRET_KEY_PQ_PREFIX, secretKey).getOrThrow()
+
+  public companion object {
+    internal const val AGE_SECRET_KEY_PQ_PREFIX = "AGE-SECRET-KEY-PQ-"
+
+    /** Decodes an `AGE-SECRET-KEY-PQ-` Bech32 string into an MLKEM768-X25519 identity. */
+    public fun decode(string: String): MlKem768X25519Identity {
+      val (hrp, key) =
+        Bech32.decode(string)
+          .mapError { MlKem768X25519IdentityException("Invalid private key", it) }
+          .getOrThrow()
+
+      if (hrp != AGE_SECRET_KEY_PQ_PREFIX)
+        throw MlKem768X25519IdentityException(
+          "Invalid human readable part for age secret key ($hrp)"
+        )
+
+      return MlKem768X25519Identity(key)
+    }
+
+    /** Generates a new [kage.crypto.mlkem.MlKem768X25519Identity] with a random private key. */
+    public fun new(): MlKem768X25519Identity {
+      val secretKey = ByteArray(MlKem768X25519.SEED_SIZE)
+      SecureRandom().nextBytes(secretKey)
+
+      return MlKem768X25519Identity(secretKey)
+    }
+  }
+}

--- a/src/kotlin/kage/crypto/mlkem/MlKem768X25519Identity.kt
+++ b/src/kotlin/kage/crypto/mlkem/MlKem768X25519Identity.kt
@@ -26,9 +26,10 @@ import kage.utils.decodeBase64
  *
  * @param secretKey Raw 32 byte seed the key pair is derived from.
  */
-public class MlKem768X25519Identity(private val secretKey: ByteArray) : Identity {
+public class MlKem768X25519Identity(secretKey: ByteArray) : Identity {
 
-  private val privateKey = MlKem768X25519.newPrivateKey(secretKey)
+  private val secretKey = secretKey.copyOf()
+  private val privateKey = MlKem768X25519.newPrivateKey(this.secretKey)
 
   private fun unwrapSingle(stanza: AgeStanza): ByteArray {
     if (stanza.type != MLKEM768X25519_STANZA_TYPE) throw IncorrectIdentityException()

--- a/src/kotlin/kage/crypto/mlkem/MlKem768X25519Recipient.kt
+++ b/src/kotlin/kage/crypto/mlkem/MlKem768X25519Recipient.kt
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2026 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.mlkem
+
+import com.github.michaelbull.result.getOrThrow
+import com.github.michaelbull.result.mapError
+import kage.Recipient
+import kage.RecipientWithLabels
+import kage.errors.InvalidRecipientException
+import kage.format.AgeStanza
+import kage.format.Bech32
+import kage.utils.encodeBase64
+
+/**
+ * An age recipient backed by an MLKEM768-X25519 (X-Wing) public key.
+ *
+ * @param publicKey Raw public key, an ML-KEM-768 encapsulation key followed by an X25519 public
+ *   key.
+ */
+public class MlKem768X25519Recipient(private val publicKey: ByteArray) :
+  Recipient, RecipientWithLabels {
+
+  override fun wrap(fileKey: ByteArray): List<AgeStanza> = wrapWithLabels(fileKey).first
+
+  /**
+   * Wraps [fileKey] and returns the `postquantum` label, which stops this recipient from being
+   * mixed with recipients that would defeat its post-quantum security.
+   */
+  override fun wrapWithLabels(fileKey: ByteArray): Pair<List<AgeStanza>, List<String>> {
+    val (sharedSecret, enc) = MlKem768X25519.encapsulate(publicKey)
+
+    val wrappedKey = Hpke.seal(sharedSecret, MLKEM768X25519_INFO.toByteArray(), fileKey)
+
+    val stanza = AgeStanza(MLKEM768X25519_STANZA_TYPE, listOf(enc.encodeBase64()), wrappedKey)
+
+    return Pair(listOf(stanza), listOf(POST_QUANTUM_LABEL))
+  }
+
+  /** Encodes this recipient as an `age1pq1...` Bech32 public key. */
+  public fun encodeToString(): String =
+    Bech32.encode(AGE_PUBLIC_KEY_PQ_PREFIX, publicKey).getOrThrow()
+
+  public companion object {
+    internal const val MLKEM768X25519_STANZA_TYPE = "mlkem768x25519"
+    internal const val MLKEM768X25519_INFO = "age-encryption.org/mlkem768x25519"
+    internal const val AGE_PUBLIC_KEY_PQ_PREFIX = "age1pq"
+    internal const val POST_QUANTUM_LABEL = "postquantum"
+
+    /** Decodes an `age1pq1...` Bech32 public key into an MLKEM768-X25519 recipient. */
+    public fun decode(string: String): MlKem768X25519Recipient {
+      val (hrp, key) =
+        Bech32.decode(string)
+          .mapError { InvalidRecipientException("Invalid public key", it) }
+          .getOrThrow()
+
+      if (key.size != MlKem768X25519.PUBLIC_KEY_SIZE)
+        throw InvalidRecipientException("Invalid key size for age public key (${key.size})")
+
+      if (hrp != AGE_PUBLIC_KEY_PQ_PREFIX)
+        throw InvalidRecipientException("Invalid human readable part for age public key ($hrp)")
+
+      return MlKem768X25519Recipient(key)
+    }
+  }
+}

--- a/src/kotlin/kage/crypto/mlkem/MlKem768X25519Recipient.kt
+++ b/src/kotlin/kage/crypto/mlkem/MlKem768X25519Recipient.kt
@@ -20,8 +20,9 @@ import kage.utils.encodeBase64
  * @param publicKey Raw public key, an ML-KEM-768 encapsulation key followed by an X25519 public
  *   key.
  */
-public class MlKem768X25519Recipient(private val publicKey: ByteArray) :
-  Recipient, RecipientWithLabels {
+public class MlKem768X25519Recipient(publicKey: ByteArray) : Recipient, RecipientWithLabels {
+
+  private val publicKey = publicKey.copyOf().also(MlKem768X25519::validatePublicKey)
 
   override fun wrap(fileKey: ByteArray): List<AgeStanza> = wrapWithLabels(fileKey).first
 

--- a/src/kotlin/kage/crypto/mlkem/MlKem768X25519Recipient.kt
+++ b/src/kotlin/kage/crypto/mlkem/MlKem768X25519Recipient.kt
@@ -25,10 +25,6 @@ public class MlKem768X25519Recipient(private val publicKey: ByteArray) :
 
   override fun wrap(fileKey: ByteArray): List<AgeStanza> = wrapWithLabels(fileKey).first
 
-  /**
-   * Wraps [fileKey] and returns the `postquantum` label, which stops this recipient from being
-   * mixed with recipients that would defeat its post-quantum security.
-   */
   override fun wrapWithLabels(fileKey: ByteArray): Pair<List<AgeStanza>, List<String>> {
     val (sharedSecret, enc) = MlKem768X25519.encapsulate(publicKey)
 

--- a/src/kotlin/kage/crypto/stream/ChaCha20Poly1305.kt
+++ b/src/kotlin/kage/crypto/stream/ChaCha20Poly1305.kt
@@ -7,9 +7,13 @@ package kage.crypto.stream
 
 import kage.errors.IncorrectCipherTextSizeException
 import kotlin.math.max
+import org.bouncycastle.crypto.InvalidCipherTextException
 import org.bouncycastle.crypto.modes.ChaCha20Poly1305
 import org.bouncycastle.crypto.params.AEADParameters
 import org.bouncycastle.crypto.params.KeyParameter
+
+/** The authentication tag of an otherwise structurally valid AEAD ciphertext did not verify. */
+internal class AeadAuthenticationException(cause: Throwable) : Exception(cause)
 
 internal object ChaCha20Poly1305 {
   const val MAC_SIZE: Int = 16 // bytes
@@ -95,7 +99,11 @@ internal object ChaCha20Poly1305 {
 
     if (input.size != expectedPlaintextSize + MAC_SIZE) throw IncorrectCipherTextSizeException()
 
-    decrypt(key, nonce, input, 0, input.size, out, 0)
+    try {
+      decrypt(key, nonce, input, 0, input.size, out, 0)
+    } catch (err: InvalidCipherTextException) {
+      throw AeadAuthenticationException(err)
+    }
 
     return out
   }

--- a/src/kotlin/kage/crypto/stream/ChaCha20Poly1305.kt
+++ b/src/kotlin/kage/crypto/stream/ChaCha20Poly1305.kt
@@ -93,11 +93,10 @@ internal object ChaCha20Poly1305 {
    * which has limited impact.
    */
   fun aeadDecrypt(key: ByteArray, input: ByteArray, expectedPlaintextSize: Int): ByteArray {
-    val out = ByteArray(max(0, input.size - MAC_SIZE))
-
-    val nonce = ByteArray(NONCE_LENGTH)
-
     if (input.size != expectedPlaintextSize + MAC_SIZE) throw IncorrectCipherTextSizeException()
+
+    val out = ByteArray(max(0, input.size - MAC_SIZE))
+    val nonce = ByteArray(NONCE_LENGTH)
 
     try {
       decrypt(key, nonce, input, 0, input.size, out, 0)

--- a/src/kotlin/kage/crypto/x25519/X25519Identity.kt
+++ b/src/kotlin/kage/crypto/x25519/X25519Identity.kt
@@ -11,6 +11,7 @@ import com.github.michaelbull.result.mapError
 import java.security.SecureRandom
 import kage.Age
 import kage.Identity
+import kage.crypto.stream.AeadAuthenticationException
 import kage.crypto.stream.ChaCha20Poly1305
 import kage.crypto.x25519.X25519Recipient.Companion.MAC_KEY_LENGTH
 import kage.crypto.x25519.X25519Recipient.Companion.X25519_INFO
@@ -53,6 +54,8 @@ public class X25519Identity(private val secretKey: ByteArray, private val public
         hkdf.extractAndExpand(salt, sharedSecret, X25519_INFO.toByteArray(), MAC_KEY_LENGTH)
 
       return ChaCha20Poly1305.aeadDecrypt(wrappingKey, stanza.body, Age.FILE_KEY_SIZE)
+    } catch (err: AeadAuthenticationException) {
+      throw IncorrectIdentityException(err)
     } catch (err: Exception) {
       if (err is X25519IdentityException) {
         throw err

--- a/src/kotlin/kage/errors/CryptoException.kt
+++ b/src/kotlin/kage/errors/CryptoException.kt
@@ -41,6 +41,14 @@ public class X25519IdentityException
 constructor(message: String? = null, cause: Throwable? = null) :
   InvalidIdentityException(message, cause)
 
+/**
+ * Raised when an error occurs when unwrapping an MLKEM768-X25519 stanza from an [kage.Identity].
+ */
+public class MlKem768X25519IdentityException
+@JvmOverloads
+constructor(message: String? = null, cause: Throwable? = null) :
+  InvalidIdentityException(message, cause)
+
 /** Raised when an error occurs when unwrapping an SSH stanza from an [kage.Identity]. */
 public class SshIdentityException
 @JvmOverloads

--- a/src/kotlin/kage/format/Bech32.kt
+++ b/src/kotlin/kage/format/Bech32.kt
@@ -116,9 +116,6 @@ internal object Bech32 {
         },
       )
 
-    if (hrp.length + values.size + 7 > 90) {
-      return Err(Bech32Exception("too long: hrp length=${hrp.length}, data length=${values.size}"))
-    }
     if (hrp.isEmpty()) {
       return Err(Bech32Exception("invalid HRP: $hrp"))
     }
@@ -149,9 +146,6 @@ internal object Bech32 {
 
   // Decode decodes a Bech32 string. If the string is uppercase, the HRP will be uppercase.
   fun decode(s: String): Bech32Result<Pair<String, ByteArray>> {
-    if (s.length > 90) {
-      return Err(Bech32Exception("too long: len=${s.length}"))
-    }
     if (s.lowercase() != s && s.uppercase() != s) {
       return Err(Bech32Exception("mixed case"))
     }

--- a/src/kotlin/kage/format/MlKem768X25519KeyFile.kt
+++ b/src/kotlin/kage/format/MlKem768X25519KeyFile.kt
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2026 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.format
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import kage.crypto.mlkem.MlKem768X25519Identity
+import kage.crypto.mlkem.MlKem768X25519Identity.Companion.AGE_SECRET_KEY_PQ_PREFIX
+import kage.crypto.mlkem.MlKem768X25519Recipient
+import kage.crypto.mlkem.MlKem768X25519Recipient.Companion.AGE_PUBLIC_KEY_PQ_PREFIX
+import kage.errors.InvalidAgeKeyException
+import kage.utils.writeNewLine
+
+/**
+ * The contents of an age MLKEM768-X25519 identity file.
+ *
+ * @property created Value from the file's `created` comment.
+ * @property publicKey Public key from the file, if present.
+ * @property privateKey Private MLKEM768-X25519 identity from the file.
+ */
+public class MlKem768X25519KeyFile(
+  public val created: String,
+  public val publicKey: MlKem768X25519Recipient?,
+  public val privateKey: MlKem768X25519Identity,
+) {
+  override fun equals(other: Any?): Boolean {
+    if (other == null) return false
+    if (other !is MlKem768X25519KeyFile) return false
+
+    if (this === other) return true
+
+    if (!privateKey.equals(other.privateKey)) return false
+    if (publicKey?.equals(other.publicKey) != true) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = privateKey.hashCode()
+    result = 31 * result + publicKey.hashCode()
+    return result
+  }
+
+  internal companion object {
+
+    fun parse(reader: BufferedReader): MlKem768X25519KeyFile {
+      val lines = reader.readLines()
+      var created = ""
+      var publicKeyStr = ""
+      var privateKeyStr = ""
+
+      lines.forEach { line ->
+        if (line.startsWith("# created: ")) {
+          created = parseCreatedLine(line)
+        } else if (line.startsWith("# public key: ")) {
+          publicKeyStr = parsePublicKeyLine(line)
+        } else if (line.startsWith(AGE_SECRET_KEY_PQ_PREFIX)) {
+          privateKeyStr = line
+        }
+      }
+
+      if (privateKeyStr.isEmpty())
+        throw InvalidAgeKeyException("Cannot find private key in age key file")
+
+      val privateKey = MlKem768X25519Identity.decode(privateKeyStr)
+
+      val publicKey =
+        if (publicKeyStr.isEmpty()) null else MlKem768X25519Recipient.decode(publicKeyStr)
+
+      return MlKem768X25519KeyFile(created, publicKey, privateKey)
+    }
+
+    internal fun write(writer: BufferedWriter, keyFile: MlKem768X25519KeyFile) {
+      writer.write("# created: ${keyFile.created}")
+      writer.writeNewLine()
+      if (keyFile.publicKey != null)
+        writer.write("# public key: ${keyFile.publicKey.encodeToString()}")
+      writer.writeNewLine()
+      writer.write(keyFile.privateKey.encodeToString())
+      writer.writeNewLine()
+    }
+
+    private fun parseCreatedLine(line: String): String {
+      val parts = line.split(": ")
+      if (parts.size != 2) throw InvalidAgeKeyException("Invalid created line")
+      return parts.last()
+    }
+
+    private fun parsePublicKeyLine(line: String): String {
+      val parts = line.split(": ")
+      if (parts.size != 2) throw InvalidAgeKeyException("Invalid public key line")
+      if (!parts.last().startsWith(AGE_PUBLIC_KEY_PQ_PREFIX))
+        throw InvalidAgeKeyException("Invalid public key line")
+      return parts.last()
+    }
+  }
+}

--- a/src/kotlin/kage/format/MlKem768X25519KeyFile.kt
+++ b/src/kotlin/kage/format/MlKem768X25519KeyFile.kt
@@ -33,14 +33,14 @@ public class MlKem768X25519KeyFile(
     if (this === other) return true
 
     if (!privateKey.equals(other.privateKey)) return false
-    if (publicKey?.equals(other.publicKey) != true) return false
+    if (publicKey != other.publicKey) return false
 
     return true
   }
 
   override fun hashCode(): Int {
     var result = privateKey.hashCode()
-    result = 31 * result + publicKey.hashCode()
+    result = 31 * result + (publicKey?.hashCode() ?: 0)
     return result
   }
 
@@ -69,6 +69,12 @@ public class MlKem768X25519KeyFile(
 
       val publicKey =
         if (publicKeyStr.isEmpty()) null else MlKem768X25519Recipient.decode(publicKeyStr)
+
+      if (
+        publicKey != null && publicKey.encodeToString() != privateKey.recipient().encodeToString()
+      ) {
+        throw InvalidAgeKeyException("Public key does not match private key")
+      }
 
       return MlKem768X25519KeyFile(created, publicKey, privateKey)
     }

--- a/src/kotlin/kage/format/MlKem768X25519KeyFile.kt
+++ b/src/kotlin/kage/format/MlKem768X25519KeyFile.kt
@@ -26,6 +26,14 @@ public class MlKem768X25519KeyFile(
   public val publicKey: MlKem768X25519Recipient?,
   public val privateKey: MlKem768X25519Identity,
 ) {
+  init {
+    if (
+      publicKey != null && publicKey.encodeToString() != privateKey.recipient().encodeToString()
+    ) {
+      throw InvalidAgeKeyException("Public key does not match private key")
+    }
+  }
+
   override fun equals(other: Any?): Boolean {
     if (other == null) return false
     if (other !is MlKem768X25519KeyFile) return false
@@ -69,12 +77,6 @@ public class MlKem768X25519KeyFile(
 
       val publicKey =
         if (publicKeyStr.isEmpty()) null else MlKem768X25519Recipient.decode(publicKeyStr)
-
-      if (
-        publicKey != null && publicKey.encodeToString() != privateKey.recipient().encodeToString()
-      ) {
-        throw InvalidAgeKeyException("Public key does not match private key")
-      }
 
       return MlKem768X25519KeyFile(created, publicKey, privateKey)
     }

--- a/src/test/kotlin/kage/DetachedHeaderTest.kt
+++ b/src/test/kotlin/kage/DetachedHeaderTest.kt
@@ -11,8 +11,8 @@ import java.io.ByteArrayOutputStream
 import kage.crypto.stream.ArmorOutputStream
 import kage.crypto.x25519.X25519Identity
 import kage.errors.IncorrectHMACException
+import kage.errors.IncorrectIdentityException
 import kage.errors.NoIdentitiesException
-import kage.errors.X25519IdentityException
 import kage.format.AgeHeader
 import kage.format.AgeStanza
 import org.junit.jupiter.api.Test
@@ -79,8 +79,8 @@ class DetachedHeaderTest {
 
     val header = Age.extractHeader(ByteArrayInputStream(ciphertext))
 
-    assertThrows<X25519IdentityException> { Age.decryptHeader(header, listOf(otherIdentity)) }
-    assertThrows<X25519IdentityException> {
+    assertThrows<IncorrectIdentityException> { Age.decryptHeader(header, listOf(otherIdentity)) }
+    assertThrows<IncorrectIdentityException> {
       Age.decryptStream(
         listOf(otherIdentity),
         ByteArrayInputStream(ciphertext),

--- a/src/test/kotlin/kage/UpstreamTestSuite.kt
+++ b/src/test/kotlin/kage/UpstreamTestSuite.kt
@@ -29,10 +29,6 @@ class UpstreamTestSuite {
     return Files.newDirectoryStream(testFixtureRoot).map { path ->
       val contents = path.toFile().readBytes()
       DynamicTest.dynamicTest(path.name) {
-        // Skip hybrid post-quantum crypto
-        if (path.name.contains("hybrid")) {
-          return@dynamicTest
-        }
         val suite = TestSuite.parse(contents)
         val expect = suite.expect
 

--- a/src/test/kotlin/kage/crypto/mlkem/MlKem768X25519RecipientTest.kt
+++ b/src/test/kotlin/kage/crypto/mlkem/MlKem768X25519RecipientTest.kt
@@ -18,6 +18,8 @@ import kage.errors.IncorrectIdentityException
 import kage.errors.InvalidRecipientException
 import kage.errors.InvalidScryptRecipientException
 import kage.errors.MlKem768X25519IdentityException
+import kage.format.AgeFile
+import kage.format.AgeHeader
 import kage.format.AgeStanza
 import kage.format.Bech32
 import kage.utils.decodeBase64
@@ -126,6 +128,20 @@ class MlKem768X25519RecipientTest {
 
     assertThrows<MlKem768X25519IdentityException> {
       testIdentity.unwrap(listOf(malformedStanza, validStanza))
+    }
+  }
+
+  @Test
+  fun testRejectsMalformedMatchingStanzaBeforeAnotherIdentityCanDecrypt() {
+    val x25519Identity = X25519Identity.new()
+    val ageFile = Age.encrypt(listOf(x25519Identity.recipient()), "plaintext".byteInputStream())
+    val fileKey = x25519Identity.unwrap(ageFile.header.recipients)
+    val malformedStanza = AgeStanza("mlkem768x25519", emptyList(), ByteArray(0))
+    val header = AgeHeader.withMac(listOf(malformedStanza).plus(ageFile.header.recipients), fileKey)
+    val malformedAgeFile = AgeFile(header, ageFile.body)
+
+    assertThrows<MlKem768X25519IdentityException> {
+      Age.decrypt(listOf(testIdentity, x25519Identity), malformedAgeFile)
     }
   }
 

--- a/src/test/kotlin/kage/crypto/mlkem/MlKem768X25519RecipientTest.kt
+++ b/src/test/kotlin/kage/crypto/mlkem/MlKem768X25519RecipientTest.kt
@@ -5,6 +5,7 @@
  */
 package kage.kage.crypto.mlkem
 
+import com.github.michaelbull.result.getOrThrow
 import com.google.common.truth.Truth.assertThat
 import java.io.ByteArrayOutputStream
 import java.util.Random
@@ -18,6 +19,7 @@ import kage.errors.InvalidRecipientException
 import kage.errors.InvalidScryptRecipientException
 import kage.errors.MlKem768X25519IdentityException
 import kage.format.AgeStanza
+import kage.format.Bech32
 import kage.utils.decodeBase64
 import kage.utils.encodeBase64
 import org.junit.jupiter.api.Test
@@ -153,6 +155,47 @@ class MlKem768X25519RecipientTest {
     assertThrows<IncorrectCipherTextSizeException> {
       testIdentity.unwrap(listOf(AgeStanza(stanza.type, stanza.args, stanza.body.plus(0))))
     }
+  }
+
+  @Test
+  fun testIdentityCopiesSeedBeforeDerivingKeyPair() {
+    val seed = ByteArray(32) { it.toByte() }
+    val identity = MlKem768X25519Identity(seed)
+    val expectedRecipient = identity.recipient().encodeToString()
+
+    seed.fill(0)
+
+    assertThat(
+        MlKem768X25519Identity.decode(identity.encodeToString()).recipient().encodeToString()
+      )
+      .isEqualTo(expectedRecipient)
+  }
+
+  @Test
+  fun testRecipientCopiesPublicKey() {
+    val publicKey = Bech32.decode(testIdentity.recipient().encodeToString()).getOrThrow().second
+    val recipient = MlKem768X25519Recipient(publicKey)
+    val expectedEncoding = recipient.encodeToString()
+
+    publicKey.fill(0)
+
+    assertThat(recipient.encodeToString()).isEqualTo(expectedEncoding)
+  }
+
+  @Test
+  fun testDecodeRejectsMalformedMlKemPublicKey() {
+    val malformedKey = Bech32.encode("age1pq", ByteArray(1216) { 0xff.toByte() }).getOrThrow()
+
+    assertThrows<InvalidRecipientException> { MlKem768X25519Recipient.decode(malformedKey) }
+  }
+
+  @Test
+  fun testDecodeRejectsLowOrderX25519PublicKey() {
+    val publicKey = Bech32.decode(testIdentity.recipient().encodeToString()).getOrThrow().second
+    publicKey.fill(0, publicKey.size - 32, publicKey.size)
+    val malformedKey = Bech32.encode("age1pq", publicKey).getOrThrow()
+
+    assertThrows<InvalidRecipientException> { MlKem768X25519Recipient.decode(malformedKey) }
   }
 
   @Test

--- a/src/test/kotlin/kage/crypto/mlkem/MlKem768X25519RecipientTest.kt
+++ b/src/test/kotlin/kage/crypto/mlkem/MlKem768X25519RecipientTest.kt
@@ -1,0 +1,178 @@
+/**
+ * Copyright 2026 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.kage.crypto.mlkem
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayOutputStream
+import java.util.Random
+import kage.Age
+import kage.crypto.mlkem.MlKem768X25519Identity
+import kage.crypto.mlkem.MlKem768X25519Recipient
+import kage.crypto.x25519.X25519Identity
+import kage.errors.IncorrectCipherTextSizeException
+import kage.errors.IncorrectIdentityException
+import kage.errors.InvalidRecipientException
+import kage.errors.InvalidScryptRecipientException
+import kage.errors.MlKem768X25519IdentityException
+import kage.format.AgeStanza
+import kage.utils.decodeBase64
+import kage.utils.encodeBase64
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class MlKem768X25519RecipientTest {
+
+  private val testIdentity =
+    MlKem768X25519Identity.decode(
+      "AGE-SECRET-KEY-PQ-1HZLGZUPT4ETPKDEV8HSGFDCYZ4E522W0A7PU2LHT8EH9W6YLNC3SW78XKG"
+    )
+
+  private fun wrapFileKey(): AgeStanza {
+    val fileKey = ByteArray(Age.FILE_KEY_SIZE)
+    Random().nextBytes(fileKey)
+    return testIdentity.recipient().wrap(fileKey).first()
+  }
+
+  @Test
+  fun testWrapUnwrap() {
+    val identity = MlKem768X25519Identity.new()
+    val recipient = identity.recipient()
+
+    val fileKey = ByteArray(Age.FILE_KEY_SIZE)
+    Random().nextBytes(fileKey)
+
+    val (stanzas, labels) = recipient.wrapWithLabels(fileKey)
+    val stanza = stanzas.first()
+
+    assertThat(stanza.type).isEqualTo("mlkem768x25519")
+    assertThat(stanza.args).hasSize(1)
+    assertThat(stanza.args.first().decodeBase64()).hasLength(1120)
+    assertThat(stanza.body).hasLength(Age.FILE_KEY_SIZE + 16)
+    assertThat(labels).containsExactly("postquantum")
+
+    val unwrapped = identity.unwrap(listOf(stanza))
+
+    assertThat(fileKey).asList().containsExactlyElementsIn(unwrapped.asList())
+  }
+
+  @Test
+  fun testEncryptDecrypt() {
+    val identity = MlKem768X25519Identity.new()
+    val plainText = "The quick brown fox jumps over the lazy dog"
+
+    val ageFile = Age.encrypt(listOf(identity.recipient()), plainText.byteInputStream())
+
+    val out = ByteArrayOutputStream()
+    Age.decrypt(identity, ageFile).use { it.copyTo(out) }
+
+    assertThat(out.toString()).isEqualTo(plainText)
+  }
+
+  @Test
+  fun testRejectsMixingWithX25519() {
+    val recipients =
+      listOf(MlKem768X25519Identity.new().recipient(), X25519Identity.new().recipient())
+
+    assertThrows<InvalidScryptRecipientException> {
+      Age.encrypt(recipients, "".byteInputStream())
+    }
+  }
+
+  @Test
+  fun testEncodeDecodeIdentity() {
+    val identity = MlKem768X25519Identity.new()
+    val encoded = identity.encodeToString()
+
+    assertThat(encoded).startsWith("AGE-SECRET-KEY-PQ-1")
+    assertThat(MlKem768X25519Identity.decode(encoded).encodeToString()).isEqualTo(encoded)
+  }
+
+  @Test
+  fun testRecipientDerivation() {
+    // Recipient for [testIdentity] as derived by age.
+    assertThat(testIdentity.recipient().encodeToString())
+      .isEqualTo(
+        "age1pq1z4f9zeapqujpskesfxhujkg525ymk8mep9up4wa7kxsycgvtc3ef0fqrrs79pszxh3gu7zyl2k5r4drv44smvshlqfwwl7ycrg2vd24k8ut9fdwevmrx44jzrqgzq473xwp8xefy5zt48f4f4ggkvduppkes9q7pjkdmjugrvkvq3vnhyuk20skhkscaypuq3zeu20dcgxwcnzsg2gmv8uyurlvhpx9s4xe8qxeq709c5s2a63nxekcjy7aav5a8je8csgyc4m4uvz9tz6s9tpuu0yqns7raa0gx5t6x4qv3j2phzyje60q4tlmm60vhz85pvmhcs88fs44rp6vcqapjszdv5yy0kc9s7sqggdwg5yx9q4llx76ts345njwrszv360dhwf3w3ffeu3qg9d4g6s2mwhgggzt68qk0y5hxlpa9e37fzn2k0z7tzwtwuf6cdkm0655c9r09x8w602vke986h6362cprm86uy67sqgzjc9tuuyck4egpz2l4rz69xlgg6wumzu4jynqtp8c6t4srycfkdjj0wzqrad9qpztxyf92eq3vl323j7mlra9p8vrtq648vkkqcjjczksm9z4epfwu4tn6xuu0sgyykyggqzxsf3zudjv33pww9gyxz9fm3caxf3mu8nsc3z68sgkhsej2ae6vmw8vvgjlp3c2cm9ac6a9q9ae08y5hs4hktu4rz7kkcujf4580l5qp7e0zpj454frja2aht9j6s9gkpwww73vr3wrdpa438c554l80j670fp4stx3n5zylq7qgzmm9gmzzzasfq2zjhz06494xqfsywwsqun866dz8kaw0758ejgn5d0axshwuxsjwxnpl99q5exr5ynrg9jkdgulrgzwynjnn9wpyxudr24dvejy8yraask8z3uksyvnndcjd9jcgcjhd2j2g8tv8lu08xzl4vmrquctdcputtdhw4tlqavt75dwtsdq3rgxhk75ftadquumkgl00kxxvuqfztmyqpugq5wq2jh9766lln55y26x3sd403sl6jk9agwxjsz9ggwxj54czrnwd2ruw73c2g35mfut9w548w9wwqtue76msnangew3t7qwd8lusy6evgnd4ryn6mn2ew605r6ztqnrcxvls2u4yr6mzy7ek6vazlyfj5jq0pqnsnwc8v4jt8we2qptcnrhajjzhggvwjke09sep3yzh3j2hhevh25pf98qshc63vkw6nzvcv39xlaqw4g0t8cg6fsk7fr967ezssuxj827gpt2p30vq2275e4z42rpvlyqv5vfkgzpqwjnqh9kax34pht69vcm8fpaupur6cdsqn7pqedrx76xmffvkzurxduxfm5md2h8zhmw8syq7wxtnfr8knpec8h88drcynzm7594njqy39nvk7py57zms4e64uapwwrphjmu4ktdx48hmjsv0cwtfmm2a04cfwahr385xwjszvymwvpxnr23x8kf4watqch9llz95gvnrzqezuvmfshattpthutm50je7kjgs4a4vx9hwyc6mly64ss3cn5j2ue2c00xy6tw5psjuafnyxnjvwcuff2ntx7vvwmt6knfg46t0tunsa35asg4vc5yxqyujfvtyhlx8yy24p29jxfkq45mm0tv5fjpvghyxsc0mpryklfqa0kpgx47hpk49zsjw3erxm62cpx9rxqpxaqagsr3u5c2aycgd43q98yy5z0zpyg28rya4upnre6ps2aq9f70wvljf2948c95w4ef2cvnqfvsw5t75ju2nf524lktxfgc3nnjy32dpap32pay27n9vvml5g8uvsu9hv67l0xn76vmjpa4glwu0q4pxnp4zq0xpqusdthwyj84sue9t0jv5rg6pvkedvxguq06ktvsyv397zmxwrqqnmc60gnhas8sccjjwu0rnsa3"
+      )
+  }
+
+  @Test
+  fun testEncodeDecodeRecipient() {
+    val recipient = MlKem768X25519Identity.new().recipient()
+    val encoded = recipient.encodeToString()
+
+    assertThat(encoded).startsWith("age1pq1")
+    assertThat(MlKem768X25519Recipient.decode(encoded).encodeToString()).isEqualTo(encoded)
+  }
+
+  @Test
+  fun testIgnoresOtherStanzaTypes() {
+    val stanza = wrapFileKey()
+
+    assertThrows<IncorrectIdentityException> {
+      testIdentity.unwrap(listOf(AgeStanza("MLKEM768X25519", stanza.args, stanza.body)))
+    }
+  }
+
+  @Test
+  fun testRejectsExtraArgument() {
+    val stanza = wrapFileKey()
+
+    assertThrows<MlKem768X25519IdentityException> {
+      testIdentity.unwrap(listOf(AgeStanza(stanza.type, stanza.args.plus("extra"), stanza.body)))
+    }
+  }
+
+  @Test
+  fun testRejectsNonCanonicalEnc() {
+    val stanza = wrapFileKey()
+    val nonCanonical = stanza.args.first().dropLast(1).plus("/")
+
+    assertThrows<MlKem768X25519IdentityException> {
+      testIdentity.unwrap(listOf(AgeStanza(stanza.type, listOf(nonCanonical), stanza.body)))
+    }
+  }
+
+  @Test
+  fun testRejectsShortEnc() {
+    val stanza = wrapFileKey()
+    val short = stanza.args.first().decodeBase64().copyOfRange(0, 1119).encodeBase64()
+
+    assertThrows<MlKem768X25519IdentityException> {
+      testIdentity.unwrap(listOf(AgeStanza(stanza.type, listOf(short), stanza.body)))
+    }
+  }
+
+  @Test
+  fun testRejectsBodyOfWrongSize() {
+    val stanza = wrapFileKey()
+
+    assertThrows<IncorrectCipherTextSizeException> {
+      testIdentity.unwrap(listOf(AgeStanza(stanza.type, stanza.args, stanza.body.plus(0))))
+    }
+  }
+
+  @Test
+  fun testRejectsWrongSecretKeySize() {
+    assertThrows<MlKem768X25519IdentityException> { MlKem768X25519Identity(ByteArray(31)) }
+  }
+
+  @Test
+  fun testRejectsWrongPublicKeySize() {
+    assertThrows<InvalidRecipientException> {
+      MlKem768X25519Recipient(ByteArray(1217)).wrap(ByteArray(Age.FILE_KEY_SIZE))
+    }
+  }
+
+  @Test
+  fun testRejectsX25519Identity() {
+    assertThrows<MlKem768X25519IdentityException> {
+      MlKem768X25519Identity.decode(
+        "AGE-SECRET-KEY-1EGTZVFFV20835NWYV6270LXYVK2VKNX2MMDKWYKLMGR48UAWX40Q2P2LM0"
+      )
+    }
+  }
+}

--- a/src/test/kotlin/kage/crypto/mlkem/MlKem768X25519RecipientTest.kt
+++ b/src/test/kotlin/kage/crypto/mlkem/MlKem768X25519RecipientTest.kt
@@ -143,6 +143,9 @@ class MlKem768X25519RecipientTest {
     assertThrows<MlKem768X25519IdentityException> {
       Age.decrypt(listOf(testIdentity, x25519Identity), malformedAgeFile)
     }
+    assertThrows<MlKem768X25519IdentityException> {
+      Age.decrypt(listOf(x25519Identity, testIdentity), malformedAgeFile)
+    }
   }
 
   @Test

--- a/src/test/kotlin/kage/crypto/mlkem/MlKem768X25519RecipientTest.kt
+++ b/src/test/kotlin/kage/crypto/mlkem/MlKem768X25519RecipientTest.kt
@@ -120,6 +120,16 @@ class MlKem768X25519RecipientTest {
   }
 
   @Test
+  fun testRejectsMalformedMatchingStanzaBeforeValidStanza() {
+    val validStanza = wrapFileKey()
+    val malformedStanza = AgeStanza(validStanza.type, emptyList(), validStanza.body)
+
+    assertThrows<MlKem768X25519IdentityException> {
+      testIdentity.unwrap(listOf(malformedStanza, validStanza))
+    }
+  }
+
+  @Test
   fun testRejectsExtraArgument() {
     val stanza = wrapFileKey()
 

--- a/src/test/kotlin/kage/crypto/x25519/X25519RecipientTest.kt
+++ b/src/test/kotlin/kage/crypto/x25519/X25519RecipientTest.kt
@@ -12,7 +12,9 @@ import kage.Age
 import kage.crypto.x25519.X25519
 import kage.crypto.x25519.X25519Identity
 import kage.crypto.x25519.X25519Recipient
+import kage.errors.X25519IdentityException
 import kage.errors.X25519LowOrderPointException
+import kage.format.AgeStanza
 import kage.utils.decodeBase64
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -41,6 +43,15 @@ class X25519RecipientTest {
     val unwrapped = identity.unwrap(listOf(stanza))
 
     assertThat(fileKey).asList().containsExactlyElementsIn(unwrapped.asList())
+  }
+
+  @Test
+  fun malformedMatchingStanzaIsFatal() {
+    val identity = X25519Identity.new()
+    val stanza = identity.recipient().wrap(ByteArray(Age.FILE_KEY_SIZE)).single()
+    val malformedStanza = AgeStanza(stanza.type, stanza.args, stanza.body.plus(0))
+
+    assertThrows<X25519IdentityException> { identity.unwrap(listOf(malformedStanza, stanza)) }
   }
 
   @Test

--- a/src/test/kotlin/kage/format/Bech32Test.kt
+++ b/src/test/kotlin/kage/format/Bech32Test.kt
@@ -71,17 +71,17 @@ class Bech32Test {
           "spl" + (127).toChar() + "t1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
           false,
         ),
-        // too long
+        // long vectors that we do accept despite the spec, see age Issue 453
         T(
-          "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
-          false,
+          "long10pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7rc0pu8s7qfcsvr0",
+          true,
+        ),
+        T(
+          "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
+          true,
         ),
 
         // BIP 173 invalid vectors.
-        T(
-          "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
-          false,
-        ),
         T("pzry9x0s0muk", false),
         T("1pzry9x0s0muk", false),
         T("x1b4n0q5v", false),

--- a/src/test/kotlin/kage/format/MlKem768X25519KeyFileTest.kt
+++ b/src/test/kotlin/kage/format/MlKem768X25519KeyFileTest.kt
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2026 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.format
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayOutputStream
+import kage.crypto.mlkem.MlKem768X25519Identity
+import kage.crypto.mlkem.MlKem768X25519Recipient
+import kage.errors.InvalidAgeKeyException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class MlKem768X25519KeyFileTest {
+
+  private val secretKey =
+    "AGE-SECRET-KEY-PQ-1NQ3TF4DL0Z0K6E3RP2Q2TWGW87PZP5JGSU8EUAMMPU22W5WP688Q06M62A"
+
+  private val publicKey = MlKem768X25519Identity.decode(secretKey).recipient().encodeToString()
+
+  @Test
+  fun testMlKem768X25519KeyFile() {
+    val keyString =
+      """
+      # created: 2006-01-02T15:04:05Z07:00
+      # public key: $publicKey
+      $secretKey
+      """
+        .trimIndent()
+
+    val reader = keyString.reader().buffered()
+    val key = MlKem768X25519KeyFile.parse(reader)
+
+    assertThat(key.created).isEqualTo("2006-01-02T15:04:05Z07:00")
+    assertThat(key.publicKey?.encodeToString()).isEqualTo(publicKey)
+    assertThat(key.privateKey.encodeToString()).isEqualTo(secretKey)
+  }
+
+  @Test
+  fun testMlKem768X25519KeyWithOnlyPrivateKey() {
+    val keyString = secretKey
+
+    val reader = keyString.reader().buffered()
+    val key = MlKem768X25519KeyFile.parse(reader)
+
+    assertThat(key.privateKey.encodeToString()).isEqualTo(secretKey)
+  }
+
+  @Test
+  fun testMlKem768X25519KeyWithInvalidPublicKeyThrowsException() {
+    val keyString =
+      """
+      # created: 2006-01-02T15:04:05Z07:00
+      # public key: not a valid public key
+      $secretKey
+      """
+        .trimIndent()
+
+    val reader = keyString.reader().buffered()
+
+    assertThrows<InvalidAgeKeyException> { MlKem768X25519KeyFile.parse(reader) }
+  }
+
+  @Test
+  fun testMlKem768X25519KeyWithX25519PublicKeyThrowsException() {
+    val keyString =
+      """
+      # created: 2006-01-02T15:04:05Z07:00
+      # public key: age1mrmfnwhtlprn4jquex0ukmwcm7y2nxlphuzgsgv8ew2k9mewy3rs8u7su5
+      $secretKey
+      """
+        .trimIndent()
+
+    val reader = keyString.reader().buffered()
+
+    assertThrows<InvalidAgeKeyException> { MlKem768X25519KeyFile.parse(reader) }
+  }
+
+  @Test
+  fun testExtraDataIsIgnored() {
+    val keyString =
+      """
+      # created: 2006-01-02T15:04:05Z07:00
+      # something funny
+      # not really
+      $secretKey
+      """
+        .trimIndent()
+
+    val reader = keyString.reader().buffered()
+    val key = MlKem768X25519KeyFile.parse(reader)
+
+    assertThat(key.created).isEqualTo("2006-01-02T15:04:05Z07:00")
+    assertThat(key.privateKey.encodeToString()).isEqualTo(secretKey)
+  }
+
+  @Test
+  fun testMlKem768X25519KeyWithInvalidPrivateKeyThrowsException() {
+    val keyString =
+      """
+      # created: 2006-01-02T15:04:05Z07:00
+      1NQ3TF4DL0Z0K6E3RP2Q2TWGW87PZP5JGSU8EUAMMPU22W5WP688Q06M62A
+      """
+        .trimIndent()
+
+    val reader = keyString.reader().buffered()
+
+    assertThrows<InvalidAgeKeyException> { MlKem768X25519KeyFile.parse(reader) }
+  }
+
+  @Test
+  fun testX25519PrivateKeyIsNotParsed() {
+    val keyString =
+      """
+      # created: 2006-01-02T15:04:05Z07:00
+      AGE-SECRET-KEY-1EKYFFCK627939WTZMTT4ZRS2PM3U2K7PZ3MVGEL2M76W3PYJMSHQMTT6SS
+      """
+        .trimIndent()
+
+    val reader = keyString.reader().buffered()
+
+    assertThrows<InvalidAgeKeyException> { MlKem768X25519KeyFile.parse(reader) }
+  }
+
+  @Test
+  fun testMlKem768X25519KeyWithDifferentOrder() {
+    val keyString =
+      """
+      $secretKey
+      # public key: $publicKey
+      # created: 2006-01-02T15:04:05Z07:00
+      """
+        .trimIndent()
+
+    val reader = keyString.reader().buffered()
+    val key = MlKem768X25519KeyFile.parse(reader)
+
+    assertThat(key.created).isEqualTo("2006-01-02T15:04:05Z07:00")
+    assertThat(key.publicKey?.encodeToString()).isEqualTo(publicKey)
+    assertThat(key.privateKey.encodeToString()).isEqualTo(secretKey)
+  }
+
+  @Test
+  fun testWrite() {
+    val keyString =
+      """
+      # created: 2006-01-02T15:04:05Z07:00
+      # public key: $publicKey
+      $secretKey
+
+      """
+        .trimIndent()
+
+    val keyFile =
+      MlKem768X25519KeyFile(
+        "2006-01-02T15:04:05Z07:00",
+        MlKem768X25519Recipient.decode(publicKey),
+        MlKem768X25519Identity.decode(secretKey),
+      )
+
+    val out = ByteArrayOutputStream()
+    val writer = out.bufferedWriter()
+    MlKem768X25519KeyFile.write(writer, keyFile)
+    writer.flush()
+
+    assertThat(out.toString()).isEqualTo(keyString)
+  }
+
+  @Test
+  fun testWriteParseRoundTrip() {
+    val identity = MlKem768X25519Identity.new()
+    val keyFile = MlKem768X25519KeyFile("2006-01-02T15:04:05Z07:00", identity.recipient(), identity)
+
+    val out = ByteArrayOutputStream()
+    val writer = out.bufferedWriter()
+    MlKem768X25519KeyFile.write(writer, keyFile)
+    writer.flush()
+
+    val parsed = MlKem768X25519KeyFile.parse(out.toString().reader().buffered())
+
+    assertThat(parsed.created).isEqualTo("2006-01-02T15:04:05Z07:00")
+    assertThat(parsed.publicKey?.encodeToString()).isEqualTo(identity.recipient().encodeToString())
+    assertThat(parsed.privateKey.encodeToString()).isEqualTo(identity.encodeToString())
+  }
+}

--- a/src/test/kotlin/kage/format/MlKem768X25519KeyFileTest.kt
+++ b/src/test/kotlin/kage/format/MlKem768X25519KeyFileTest.kt
@@ -143,6 +143,31 @@ class MlKem768X25519KeyFileTest {
   }
 
   @Test
+  fun testRejectsPublicKeyThatDoesNotMatchPrivateKey() {
+    val otherPublicKey = MlKem768X25519Identity.new().recipient().encodeToString()
+    val keyString =
+      """
+      # public key: $otherPublicKey
+      $secretKey
+      """
+        .trimIndent()
+
+    assertThrows<InvalidAgeKeyException> {
+      MlKem768X25519KeyFile.parse(keyString.reader().buffered())
+    }
+  }
+
+  @Test
+  fun testPrivateOnlyKeyFilesWithSameIdentityAreEqual() {
+    val identity = MlKem768X25519Identity.decode(secretKey)
+    val first = MlKem768X25519KeyFile("", null, identity)
+    val second = MlKem768X25519KeyFile("", null, identity)
+
+    assertThat(first).isEqualTo(second)
+    assertThat(first.hashCode()).isEqualTo(second.hashCode())
+  }
+
+  @Test
   fun testWrite() {
     val keyString =
       """

--- a/src/test/kotlin/kage/format/MlKem768X25519KeyFileTest.kt
+++ b/src/test/kotlin/kage/format/MlKem768X25519KeyFileTest.kt
@@ -158,6 +158,17 @@ class MlKem768X25519KeyFileTest {
   }
 
   @Test
+  fun testRejectsMismatchedKeysDuringConstruction() {
+    assertThrows<InvalidAgeKeyException> {
+      MlKem768X25519KeyFile(
+        "",
+        MlKem768X25519Identity.new().recipient(),
+        MlKem768X25519Identity.decode(secretKey),
+      )
+    }
+  }
+
+  @Test
   fun testPrivateOnlyKeyFilesWithSameIdentityAreEqual() {
     val identity = MlKem768X25519Identity.decode(secretKey)
     val first = MlKem768X25519KeyFile("", null, identity)

--- a/src/test/kotlin/kage/test/utils/TestSuite.kt
+++ b/src/test/kotlin/kage/test/utils/TestSuite.kt
@@ -8,6 +8,7 @@ package kage.kage.test.utils
 import java.io.ByteArrayInputStream
 import java.util.zip.InflaterInputStream
 import kage.Identity
+import kage.crypto.mlkem.MlKem768X25519Identity
 import kage.crypto.scrypt.ScryptIdentity
 import kage.crypto.x25519.X25519Identity
 import kage.test.utils.Expect
@@ -43,7 +44,7 @@ private constructor(
         when (key) {
           "expect" -> expect = Expect.fromString(value)
           "payload" -> payloadHash = PayloadHash.from(value)
-          "identity" -> identities.add(X25519Identity.decode(value))
+          "identity" -> identities.add(parseIdentity(value))
           "passphrase" -> identities.add(ScryptIdentity(value.encodeToByteArray()))
           "armored" -> armored = true
           "file key" -> {}
@@ -69,5 +70,10 @@ private constructor(
 
       return TestSuite(expect, payloadHash, identities, armored, remaining)
     }
+
+    private fun parseIdentity(value: String): Identity =
+      if (value.startsWith(MlKem768X25519Identity.AGE_SECRET_KEY_PQ_PREFIX))
+        MlKem768X25519Identity.decode(value)
+      else X25519Identity.decode(value)
   }
 }


### PR DESCRIPTION
age v1.3.0 added native post-quantum recipients (mlkem768x25519, a.k.a. X-Wing, the type behind `age-keygen -pq`). kage doesn't have it. I want it for Mage, my Android app on kage, after a user asked for post-quantum support there.

Adds a `kage.crypto.mlkem` package: `MlKem768X25519` is the KEM (ML-KEM-768 + X25519 combined per the X-Wing construction from draft-ietf-hpke-pq/filippo.io/hpke-pq), `Hpke` is RFC 9180 base mode for the one suite this recipient type uses (HKDF-SHA256 + ChaCha20Poly1305), and `MlKem768X25519Identity`/`Recipient` mirror `X25519Identity`/`Recipient`. Uses BouncyCastle's existing ML-KEM-768 support, no new dependency. `MlKem768X25519KeyFile` handles the `age-keygen -pq` file format.

Also drops Bech32's old 90-character BIP173 cap. A PQ recipient encodes to 1959 characters, and age's own bech32 fork dropped the same cap for the same reason (age issue 453).

Left out on purpose: `p256tag`/`mlkem768p256tag`, the hardware-plugin-compatible recipient types from the same spec page. Different feature, tied to a plugin ecosystem kage doesn't support.

All 19 hybrid CCTV vectors that were previously skipped now pass. I also cross-checked directly against the real `age`/`age-keygen` v1.3.x binaries while building this, both directions, armored and not. `testRecipientDerivation` pins a known-answer recipient string produced by real `age-keygen -pq`.

Notes for review:
- New public API in the `kage.api` diff: `MlKem768X25519Identity`, `MlKem768X25519Recipient`, `MlKem768X25519KeyFile`, `MlKem768X25519IdentityException`.
- The `postquantum` label that stops mixing a PQ recipient with non-PQ ones (matches age, confirmed against the real binary) reuses `InvalidScryptRecipientException`, the same generic label-mismatch error `ScryptRecipient` already throws. Happy to add a dedicated type if you'd rather.
- PQ key-file parsing is a new sibling class instead of a generic `AgeKeyFile`, since `Identity`/`Recipient` don't declare `encodeToString()`/`equals()`.
- Verified locally with `./gradlew check` (spotless, `checkKotlinAbi`, kover, pitest all included and green).