### PR TITLE
feat: add detached header APIs

### DIFF
--- a/api/kage.api
+++ b/api/kage.api
@@ -2,16 +2,23 @@ public final class kage/Age {
 	public static final field INSTANCE Lkage/Age;
 	public static final fun decrypt (Ljava/util/List;Lkage/format/AgeFile;)Ljava/io/InputStream;
 	public static final fun decrypt (Lkage/Identity;Lkage/format/AgeFile;)Ljava/io/InputStream;
+	public static final fun decryptHeader ([BLjava/util/List;)[B
 	public static final fun decryptStream (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;)V
 	public static final fun encrypt (Ljava/util/List;Ljava/io/InputStream;)Lkage/format/AgeFile;
 	public static final fun encryptStream (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;Z)V
 	public static final fun encryptStream (Ljava/util/List;Ljava/io/OutputStream;Z)Ljava/io/OutputStream;
 	public static synthetic fun encryptStream$default (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;ZILjava/lang/Object;)V
 	public static synthetic fun encryptStream$default (Ljava/util/List;Ljava/io/OutputStream;ZILjava/lang/Object;)Ljava/io/OutputStream;
+	public static final fun extractHeader (Ljava/io/InputStream;)[B
 }
 
 public abstract interface class kage/Identity {
 	public abstract fun unwrap (Ljava/util/List;)[B
+}
+
+public final class kage/InjectedFileKeyIdentity : kage/Identity {
+	public fun <init> ([B)V
+	public fun unwrap (Ljava/util/List;)[B
 }
 
 public abstract interface class kage/Recipient {

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -27,6 +27,7 @@ import kage.errors.ScryptIdentityException
 import kage.format.AgeFile
 import kage.format.AgeHeader
 import kage.format.AgeStanza
+import kage.utils.readFully
 
 /** Encrypts and decrypts data using the age file format. */
 public object Age {
@@ -260,8 +261,8 @@ public object Age {
     markSupportedStream.mark(readLimit)
 
     val initialBytes = ByteArray(readLimit)
-    val bytesRead = markSupportedStream.read(initialBytes, 0, readLimit)
-    if (bytesRead == -1) {
+    val bytesRead = markSupportedStream.readFully(initialBytes)
+    if (bytesRead == 0) {
       throw InvalidHMACHeaderException("stream was too short")
     }
     val initialString = String(initialBytes, 0, bytesRead)

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -100,30 +100,8 @@ public object Age {
     srcStream: InputStream,
     dstStream: OutputStream,
   ) {
-
-    val markSupportedStream =
-      if (srcStream.markSupported()) srcStream else BufferedInputStream(srcStream)
-
-    // Check if the InputStream contains whitespace + header
-    val readLimit = ArmorInputStream.MAX_WHITESPACE + ArmorInputStream.HEADER.length
-    markSupportedStream.mark(readLimit)
-
-    val initialBytes = ByteArray(readLimit)
-    val bytesRead = markSupportedStream.read(initialBytes, 0, readLimit)
-    if (bytesRead == -1) {
-      throw InvalidHMACHeaderException("stream was too short")
-    }
-    val initialString = String(initialBytes, 0, bytesRead)
-
-    markSupportedStream.reset()
-
-    val decodedStream =
-      if (initialString.contains(ArmorInputStream.HEADER_START)) {
-        ArmorInputStream(markSupportedStream)
-      } else markSupportedStream
-
     // Parse only the header, then stream the payload — avoids buffering the whole body in memory.
-    decryptStreamInternal(identities, decodedStream.buffered(), dstStream)
+    decryptStreamInternal(identities, decodeArmor(srcStream).buffered(), dstStream)
   }
 
   /**
@@ -140,6 +118,39 @@ public object Age {
   @JvmStatic
   public fun decrypt(identity: Identity, ageFile: AgeFile): InputStream =
     decryptInternal(listOf(identity), ageFile)
+
+  /**
+   * Returns the detached header of the age file in [srcStream], leaving its payload untouched.
+   *
+   * Both binary and ASCII-armored ciphertext are accepted, and the header is always returned in its
+   * binary form. The detached header can be decrypted with [decryptHeader], for example on a
+   * different system, without sharing the payload.
+   *
+   * This is a low-level method that most users won't need.
+   */
+  @JvmStatic
+  public fun extractHeader(srcStream: InputStream): ByteArray {
+    val header = AgeHeader.parse(decodeArmor(srcStream).buffered())
+
+    val out = ByteArrayOutputStream()
+    out.bufferedWriter().use { writer -> header.write(writer) }
+
+    return out.toByteArray()
+  }
+
+  /**
+   * Decrypts a detached [header] produced by [extractHeader] with one of [identities] and returns
+   * the file key it wraps.
+   *
+   * The file key can be handed to [InjectedFileKeyIdentity] to decrypt the corresponding payload.
+   * It is the caller's responsibility to keep track of which file the returned key decrypts, and to
+   * ensure it is not used for any other purpose.
+   *
+   * This is a low-level method that most users won't need.
+   */
+  @JvmStatic
+  public fun decryptHeader(header: ByteArray, identities: List<Identity>): ByteArray =
+    resolveFileKey(identities, AgeHeader.parse(ByteArrayInputStream(header).buffered()))
 
   private fun encryptInternal(
     recipients: List<Recipient>,
@@ -204,57 +215,10 @@ public object Age {
     return fileKey
   }
 
-  private fun decryptInternal(identities: List<Identity>, ageFile: AgeFile): InputStream {
+  // Unwraps the file key from [header] with the first matching identity and authenticates the
+  // header against it. Shared by every decryption entry point so they cannot drift apart.
+  private fun resolveFileKey(identities: List<Identity>, header: AgeHeader): ByteArray {
     if (identities.isEmpty()) throw NoIdentitiesException("no identities specified")
-
-    val exceptions = mutableListOf<Exception>()
-
-    ageFile.header.recipients.forEach { stanza ->
-      if (stanza.type == ScryptRecipient.SCRYPT_STANZA_TYPE && ageFile.header.recipients.size != 1)
-        throw ScryptIdentityException("an scrypt identity must be the only one")
-    }
-
-    for (identity in identities) {
-      val fileKey =
-        try {
-          identity.unwrap(ageFile.header.recipients)
-        } catch (err: Exception) {
-          exceptions.add(err)
-          continue
-        }
-
-      if (ageFile.header.mac.size != HMAC_SIZE)
-        throw InvalidHMACHeaderException("invalid header mac")
-
-      val calculatedMac = Primitives.headerMAC(fileKey, ageFile.header)
-
-      if (!MessageDigest.isEqual(ageFile.header.mac, calculatedMac))
-        throw IncorrectHMACException("bad header MAC")
-
-      val nonce = ByteArray(STREAM_NONCE_SIZE)
-      ageFile.body.copyInto(nonce, 0, 0, STREAM_NONCE_SIZE)
-
-      val streamKey = Primitives.streamKey(fileKey, nonce)
-
-      val bis = ByteArrayInputStream(ageFile.body)
-      bis.skip(STREAM_NONCE_SIZE.toLong())
-
-      return DecryptInputStream(streamKey, bis)
-    }
-
-    throw exceptions.reduce { acc, exception -> acc.apply { addSuppressed(exception) } }
-  }
-
-  // Streaming counterpart of decryptInternal: parses the header off [src], then decrypts the
-  // remaining live stream chunk-by-chunk into [dstStream] without holding the body in memory.
-  private fun decryptStreamInternal(
-    identities: List<Identity>,
-    src: BufferedInputStream,
-    dstStream: OutputStream,
-  ) {
-    if (identities.isEmpty()) throw NoIdentitiesException("no identities specified")
-
-    val header = AgeHeader.parse(src)
 
     header.recipients.forEach { stanza ->
       if (stanza.type == ScryptRecipient.SCRYPT_STANZA_TYPE && header.recipients.size != 1)
@@ -279,23 +243,73 @@ public object Age {
       if (!MessageDigest.isEqual(header.mac, calculatedMac))
         throw IncorrectHMACException("bad header MAC")
 
-      val nonce = ByteArray(STREAM_NONCE_SIZE)
-      var nonceOffset = 0
-      while (nonceOffset < STREAM_NONCE_SIZE) {
-        val read = src.read(nonce, nonceOffset, STREAM_NONCE_SIZE - nonceOffset)
-        if (read == -1)
-          throw InvalidNonceException("could not read payload nonce: stream truncated")
-        nonceOffset += read
-      }
-
-      val streamKey = Primitives.streamKey(fileKey, nonce)
-
-      DecryptInputStream(streamKey, src).use { decrypted ->
-        dstStream.use { dst -> decrypted.copyTo(dst) }
-      }
-      return
+      return fileKey
     }
 
     throw exceptions.reduce { acc, exception -> acc.apply { addSuppressed(exception) } }
+  }
+
+  // Wraps [srcStream] in an ArmorInputStream when it starts with an armor header, so that callers
+  // always read binary age data.
+  private fun decodeArmor(srcStream: InputStream): InputStream {
+    val markSupportedStream =
+      if (srcStream.markSupported()) srcStream else BufferedInputStream(srcStream)
+
+    // Check if the InputStream contains whitespace + header
+    val readLimit = ArmorInputStream.MAX_WHITESPACE + ArmorInputStream.HEADER.length
+    markSupportedStream.mark(readLimit)
+
+    val initialBytes = ByteArray(readLimit)
+    val bytesRead = markSupportedStream.read(initialBytes, 0, readLimit)
+    if (bytesRead == -1) {
+      throw InvalidHMACHeaderException("stream was too short")
+    }
+    val initialString = String(initialBytes, 0, bytesRead)
+
+    markSupportedStream.reset()
+
+    return if (initialString.contains(ArmorInputStream.HEADER_START)) {
+      ArmorInputStream(markSupportedStream)
+    } else markSupportedStream
+  }
+
+  private fun decryptInternal(identities: List<Identity>, ageFile: AgeFile): InputStream {
+    val fileKey = resolveFileKey(identities, ageFile.header)
+
+    val nonce = ByteArray(STREAM_NONCE_SIZE)
+    ageFile.body.copyInto(nonce, 0, 0, STREAM_NONCE_SIZE)
+
+    val streamKey = Primitives.streamKey(fileKey, nonce)
+
+    val bis = ByteArrayInputStream(ageFile.body)
+    bis.skip(STREAM_NONCE_SIZE.toLong())
+
+    return DecryptInputStream(streamKey, bis)
+  }
+
+  // Streaming counterpart of decryptInternal: parses the header off [src], then decrypts the
+  // remaining live stream chunk-by-chunk into [dstStream] without holding the body in memory.
+  private fun decryptStreamInternal(
+    identities: List<Identity>,
+    src: BufferedInputStream,
+    dstStream: OutputStream,
+  ) {
+    val header = AgeHeader.parse(src)
+
+    val fileKey = resolveFileKey(identities, header)
+
+    val nonce = ByteArray(STREAM_NONCE_SIZE)
+    var nonceOffset = 0
+    while (nonceOffset < STREAM_NONCE_SIZE) {
+      val read = src.read(nonce, nonceOffset, STREAM_NONCE_SIZE - nonceOffset)
+      if (read == -1) throw InvalidNonceException("could not read payload nonce: stream truncated")
+      nonceOffset += read
+    }
+
+    val streamKey = Primitives.streamKey(fileKey, nonce)
+
+    DecryptInputStream(streamKey, src).use { decrypted ->
+      dstStream.use { dst -> decrypted.copyTo(dst) }
+    }
   }
 }

--- a/src/kotlin/kage/InjectedFileKeyIdentity.kt
+++ b/src/kotlin/kage/InjectedFileKeyIdentity.kt
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2026 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage
+
+import kage.format.AgeStanza
+
+/**
+ * An [Identity] that unconditionally returns [fileKey], allowing the use of a file key obtained
+ * out-of-band, for example via [Age.decryptHeader].
+ *
+ * The stanzas it is handed are ignored, so the file key is only correct for the file it was
+ * obtained from. Decryption still fails on any other file because the header MAC will not match.
+ *
+ * @param fileKey Raw file key to unwrap to.
+ */
+public class InjectedFileKeyIdentity(private val fileKey: ByteArray) : Identity {
+  override fun unwrap(stanzas: List<AgeStanza>): ByteArray = fileKey
+}

--- a/src/kotlin/kage/format/AgeHeader.kt
+++ b/src/kotlin/kage/format/AgeHeader.kt
@@ -18,6 +18,7 @@ import kage.format.AgeFile.Companion.VERSION_LINE
 import kage.format.ParseUtils.splitArgs
 import kage.utils.decodeBase64
 import kage.utils.encodeBase64
+import kage.utils.readFully
 import kage.utils.readLine
 import kage.utils.writeNewLine
 import kage.utils.writeSpace
@@ -97,10 +98,11 @@ public class AgeHeader(public val recipients: List<AgeStanza>, public val mac: B
         // Add a mark to be able to reset the reader after reading the first 3 characters of the
         // line
         reader.mark(3)
-        if (reader.read(buf) == -1)
+        val peeked = reader.readFully(buf)
+        if (peeked == 0)
           throw InvalidRecipientException("End of stream reached while reading recipients")
 
-        val prefix = buf.decodeToString()
+        val prefix = buf.decodeToString(0, peeked)
         reader.reset()
 
         if (prefix.startsWith(RECIPIENT_PREFIX)) {

--- a/src/kotlin/kage/format/AgeStanza.kt
+++ b/src/kotlin/kage/format/AgeStanza.kt
@@ -20,6 +20,7 @@ import kage.format.ParseUtils.isValidArbitraryString
 import kage.format.ParseUtils.splitArgs
 import kage.utils.decodeBase64
 import kage.utils.encodeBase64
+import kage.utils.readFully
 import kage.utils.readLine
 import kage.utils.writeNewLine
 import kage.utils.writeSpace
@@ -149,8 +150,8 @@ public class AgeStanza(
         // Add a mark to be able to reset the reader after reading the first 3 characters of the
         // line
         reader.mark(3)
-        reader.read(charArray)
-        val incompleteString = charArray.decodeToString()
+        val peeked = reader.readFully(charArray)
+        val incompleteString = charArray.decodeToString(0, peeked)
 
         // Reset the reader back to the start of the line
         reader.reset()

--- a/src/kotlin/kage/utils/Extensions.kt
+++ b/src/kotlin/kage/utils/Extensions.kt
@@ -7,6 +7,7 @@ package kage.utils
 
 import java.io.BufferedInputStream
 import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import java.io.Writer
 import java.util.Base64
 import kage.errors.InvalidBase64StringException
@@ -38,6 +39,20 @@ internal fun Writer.writeNewLine() {
 
 internal fun Writer.writeSpace() {
   write(" ")
+}
+
+/**
+ * Reads into [dst] until it is full or the stream is exhausted, returning the number of bytes read
+ * (0 only at immediate EOF). A single [InputStream.read] may return fewer bytes than requested.
+ */
+internal fun InputStream.readFully(dst: ByteArray): Int {
+  var offset = 0
+  while (offset < dst.size) {
+    val n = this.read(dst, offset, dst.size - offset)
+    if (n == -1) break
+    offset += n
+  }
+  return offset
 }
 
 internal fun BufferedInputStream.readLine(): String? {

--- a/src/test/kotlin/kage/DetachedHeaderTest.kt
+++ b/src/test/kotlin/kage/DetachedHeaderTest.kt
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2026 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import kage.crypto.stream.ArmorOutputStream
+import kage.crypto.x25519.X25519Identity
+import kage.errors.IncorrectHMACException
+import kage.errors.NoIdentitiesException
+import kage.errors.X25519IdentityException
+import kage.format.AgeHeader
+import kage.format.AgeStanza
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DetachedHeaderTest {
+
+  private fun encrypt(identity: X25519Identity, payload: String): ByteArray {
+    val out = ByteArrayOutputStream()
+    Age.encryptStream(listOf(identity.recipient()), payload.byteInputStream(), out)
+    return out.toByteArray()
+  }
+
+  private fun armor(binary: ByteArray): ByteArray {
+    val out = ByteArrayOutputStream()
+    ArmorOutputStream(out).use { armored -> armored.write(binary) }
+    return out.toByteArray()
+  }
+
+  private fun serialize(header: AgeHeader): ByteArray {
+    val out = ByteArrayOutputStream()
+    out.bufferedWriter().use { writer -> header.write(writer) }
+    return out.toByteArray()
+  }
+
+  @Test
+  fun testDetachedHeaderRoundTrip() {
+    val identity = X25519Identity.new()
+    val ciphertext = encrypt(identity, "this is my file")
+
+    val header = Age.extractHeader(ByteArrayInputStream(ciphertext))
+    val fileKey = Age.decryptHeader(header, listOf(identity))
+
+    assertThat(fileKey).hasLength(Age.FILE_KEY_SIZE)
+
+    val decrypted = ByteArrayOutputStream()
+    Age.decryptStream(
+      listOf(InjectedFileKeyIdentity(fileKey)),
+      ByteArrayInputStream(ciphertext),
+      decrypted,
+    )
+
+    assertThat(decrypted.toByteArray().decodeToString()).isEqualTo("this is my file")
+  }
+
+  @Test
+  fun testExtractHeaderAcceptsArmor() {
+    val identity = X25519Identity.new()
+    val ciphertext = encrypt(identity, "this is my file")
+
+    val fromBinary = Age.extractHeader(ByteArrayInputStream(ciphertext))
+    val fromArmor = Age.extractHeader(ByteArrayInputStream(armor(ciphertext)))
+
+    assertThat(fromArmor).isEqualTo(fromBinary)
+    assertThat(fromArmor.decodeToString()).startsWith("age-encryption.org/v1\n")
+    assertThat(Age.decryptHeader(fromArmor, listOf(identity))).hasLength(Age.FILE_KEY_SIZE)
+  }
+
+  @Test
+  fun testDecryptHeaderWithWrongIdentity() {
+    val identity = X25519Identity.new()
+    val otherIdentity = X25519Identity.new()
+    val ciphertext = encrypt(identity, "this is my file")
+
+    val header = Age.extractHeader(ByteArrayInputStream(ciphertext))
+
+    assertThrows<X25519IdentityException> { Age.decryptHeader(header, listOf(otherIdentity)) }
+    assertThrows<X25519IdentityException> {
+      Age.decryptStream(
+        listOf(otherIdentity),
+        ByteArrayInputStream(ciphertext),
+        ByteArrayOutputStream(),
+      )
+    }
+  }
+
+  @Test
+  fun testDecryptHeaderWithTamperedMac() {
+    val identity = X25519Identity.new()
+    val ciphertext = encrypt(identity, "this is my file")
+
+    val header = AgeHeader.parse(ByteArrayInputStream(ciphertext).buffered())
+    val tampered = AgeHeader(header.recipients, ByteArray(header.mac.size))
+
+    assertThrows<IncorrectHMACException> {
+      Age.decryptHeader(serialize(tampered), listOf(identity))
+    }
+  }
+
+  @Test
+  fun testDecryptHeaderWithTamperedStanza() {
+    val identity = X25519Identity.new()
+    val otherIdentity = X25519Identity.new()
+
+    val header =
+      AgeHeader.parse(ByteArrayInputStream(encrypt(identity, "this is my file")).buffered())
+    val otherHeader =
+      AgeHeader.parse(ByteArrayInputStream(encrypt(otherIdentity, "this is my file")).buffered())
+    val tampered = AgeHeader(otherHeader.recipients, header.mac)
+
+    assertThrows<IncorrectHMACException> {
+      Age.decryptHeader(serialize(tampered), listOf(otherIdentity))
+    }
+  }
+
+  @Test
+  fun testDecryptHeaderWithoutIdentities() {
+    val identity = X25519Identity.new()
+    val header = Age.extractHeader(ByteArrayInputStream(encrypt(identity, "this is my file")))
+
+    assertThrows<NoIdentitiesException> { Age.decryptHeader(header, emptyList()) }
+  }
+
+  @Test
+  fun testInjectedFileKeyIdentityIgnoresStanzas() {
+    val fileKey = ByteArray(Age.FILE_KEY_SIZE) { it.toByte() }
+    val identity = InjectedFileKeyIdentity(fileKey)
+
+    assertThat(identity.unwrap(emptyList())).isEqualTo(fileKey)
+    assertThat(identity.unwrap(listOf(AgeStanza("X25519", listOf("bogus"), ByteArray(32)))))
+      .isEqualTo(fileKey)
+  }
+}

--- a/src/test/kotlin/kage/ShortReadStreamTest.kt
+++ b/src/test/kotlin/kage/ShortReadStreamTest.kt
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.security.SecureRandom
+import java.util.Base64
+import kage.crypto.x25519.X25519
+import kage.crypto.x25519.X25519Identity
+import kage.crypto.x25519.X25519Recipient
+import kage.errors.InvalidRecipientException
+import kage.format.AgeHeader
+import kage.format.AgeStanza
+import kage.utils.readLine
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ShortReadStreamTest {
+  /**
+   * Wraps an [InputStream] and never returns more than one byte per buffered [read] call, so
+   * callers that assume a single call fills the requested buffer are exercised the same way a file,
+   * SAF (`content://`), or buffered stream would break them.
+   */
+  private class ShortReadInputStream(private val delegate: InputStream) : InputStream() {
+    override fun read(): Int = delegate.read()
+
+    override fun read(b: ByteArray, off: Int, len: Int): Int {
+      if (len == 0) return 0
+      val next = delegate.read()
+      if (next == -1) return -1
+      b[off] = next.toByte()
+      return 1
+    }
+  }
+
+  private fun genX25519Identity(): Pair<X25519Recipient, X25519Identity> {
+    val privateKey = ByteArray(X25519Recipient.KEY_LENGTH)
+    SecureRandom().nextBytes(privateKey)
+    val publicKey = X25519.scalarMultBase(privateKey)
+
+    return Pair(X25519Recipient(publicKey), X25519Identity(privateKey, publicKey))
+  }
+
+  private fun shortReads(bytes: ByteArray) = ShortReadInputStream(ByteArrayInputStream(bytes))
+
+  @Test
+  fun parseRecipientsSurvivesShortReads() {
+    val headerString =
+      """
+      |age-encryption.org/v1
+      |-> X25519 SVrzdFfkPxf0LPHOUGB1gNb9E5Vr8EUDa9kxk04iQ0o
+      |0OrTkKHpE7klNLd0k+9Uam5hkQkzMxaqKcIPRIO1sNE
+      |-> X25519 8hWaIUmk67IuRZ41zMk2V9f/w3f5qUnXLL7MGPA+zE8
+      |tXgpAxKgqyu1jl9I/ATwFgV42ZbNgeAlvCTJ0WgvfEo
+      |--- gxhoSa5BciRDt8lOpYNcx4EYtKpS0CJ06F3ZwN82VaM
+      |"""
+        .trimMargin()
+
+    val header = AgeHeader.parse(shortReads(headerString.toByteArray()).buffered())
+    val actualMac = Base64.getDecoder().decode("gxhoSa5BciRDt8lOpYNcx4EYtKpS0CJ06F3ZwN82VaM")
+
+    assertThat(header.recipients).hasSize(2)
+    assertThat(header.mac).asList().containsExactlyElementsIn(actualMac.asList())
+  }
+
+  @Test
+  fun parseBodyLinesSurvivesShortReads() {
+    val stanza =
+      """
+      |-> ssh-rsa SkdmSg
+      |SW+xNSybDWTCkWx20FnCcxlfGC889s2hRxT8+giPH2DQMMFV6DyZpveqXtNwI3ts
+      |5rVkW/7hCBSqEPQwabC6O5ls75uNjeSURwHAaIwtQ6riL9arjVpHMl8O7GWSRnx3
+      |NltQt08ZpBAUkBqq5JKAr20t46ZinEIsD1LsDa2EnJrn0t8Truo2beGwZGkwkE2Y
+      |
+      |--- gxhoSa5BciRDt8lOpYNcx4EYtKpS0CJ06F3ZwN82VaM
+      |"""
+        .trimMargin()
+
+    val reader = shortReads(stanza.toByteArray()).buffered()
+
+    reader.readLine()
+
+    val body = AgeStanza.parseBodyLines(reader)
+
+    assertThat(Base64.getEncoder().withoutPadding().encodeToString(body))
+      .isEqualTo(
+        "SW+xNSybDWTCkWx20FnCcxlfGC889s2hRxT8+giPH2DQMMFV6DyZpveqXtNwI3ts" +
+          "5rVkW/7hCBSqEPQwabC6O5ls75uNjeSURwHAaIwtQ6riL9arjVpHMl8O7GWSRnx3" +
+          "NltQt08ZpBAUkBqq5JKAr20t46ZinEIsD1LsDa2EnJrn0t8Truo2beGwZGkwkE2Y"
+      )
+    assertThat(reader.readLine()).isEqualTo("--- gxhoSa5BciRDt8lOpYNcx4EYtKpS0CJ06F3ZwN82VaM")
+  }
+
+  @Test
+  fun parseBodyLinesDetectsFooterUnderShortReads() {
+    val stanza =
+      """
+      |-> X25519 SVrzdFfkPxf0LPHOUGB1gNb9E5Vr8EUDa9kxk04iQ0o
+      |SW+xNSybDWTCkWx20FnCcxlfGC889s2hRxT8+giPH2DQMMFV6DyZpveqXtNwI3ts
+      |--- gxhoSa5BciRDt8lOpYNcx4EYtKpS0CJ06F3ZwN82VaM
+      |"""
+        .trimMargin()
+
+    val reader = shortReads(stanza.toByteArray()).buffered()
+
+    reader.readLine()
+
+    val err = assertThrows<InvalidRecipientException> { AgeStanza.parseBodyLines(reader) }
+    assertThat(err).hasMessageThat().contains("Encountered the footer")
+  }
+
+  @Test
+  fun decryptStreamSurvivesShortReads() {
+    val (recipient1, identity1) = genX25519Identity()
+    val (recipient2, _) = genX25519Identity()
+
+    val payload = "this is my file"
+    val ciphertext = ByteArrayOutputStream()
+    Age.encryptStream(
+      listOf(recipient1, recipient2),
+      ByteArrayInputStream(payload.toByteArray()),
+      ciphertext,
+    )
+
+    val decrypted = ByteArrayOutputStream()
+    Age.decryptStream(listOf(identity1), shortReads(ciphertext.toByteArray()), decrypted)
+
+    assertThat(decrypted.toByteArray().decodeToString()).isEqualTo(payload)
+  }
+
+  @Test
+  fun decryptArmoredStreamSurvivesShortReads() {
+    val (recipient, identity) = genX25519Identity()
+
+    val payload = "this is my armored file"
+    val ciphertext = ByteArrayOutputStream()
+    Age.encryptStream(
+      listOf(recipient),
+      ByteArrayInputStream(payload.toByteArray()),
+      ciphertext,
+      generateArmor = true,
+    )
+
+    val decrypted = ByteArrayOutputStream()
+    Age.decryptStream(listOf(identity), shortReads(ciphertext.toByteArray()), decrypted)
+
+    assertThat(decrypted.toByteArray().decodeToString()).isEqualTo(payload)
+  }
+}


### PR DESCRIPTION
age v1.3.0 added `ExtractHeader`/`DecryptHeader`/`NewInjectedFileKeyIdentity`, for unwrapping a file's key separately from decrypting its body.

Adds `Age.extractHeader`, `Age.decryptHeader`, and `InjectedFileKeyIdentity`, which unconditionally unwraps to a fixed file key so one obtained via `decryptHeader` can be fed back into normal decryption. `decryptInternal` and `decryptStreamInternal` had duplicate copies of the same unwrap-and-authenticate loop, pulled into a shared `resolveFileKey`. Same for armor detection, now a shared `decodeArmor`.

While in there I found the same bug #555 fixed in the chunk reader, in three more places: `AgeStanza.parseBodyLines`, `AgeHeader.parseRecipients`, and `decodeArmor`'s header sniff all trusted a raw `read()` to fill a fixed buffer. A short read left stale bytes behind instead of what's actually in the stream, so a header read one byte at a time failed outright and an armored file wasn't recognized as armored. Fixed all three with a shared `readFully`, same fix as `readFull`.

Notes for review:
- New public API: `Age.extractHeader`, `Age.decryptHeader`, `InjectedFileKeyIdentity`.
- `decryptStreamInternal`'s empty-identity check now runs after parsing instead of before, so it only differs from the old behavior if you pass both an empty identity list and a malformed stream at once. Matches Go's own `Decrypt`, which parses first too.
- Verified with `./gradlew check`, and confirmed the short-read fix is load-bearing by reverting it and watching the new tests fail.