### PR TITLE
feat: add Age.decryptSeekable/encryptReader

### DIFF
--- a/api/kage.api
+++ b/api/kage.api
@@ -6,6 +6,7 @@ public final class kage/Age {
 	public static final fun decryptSeekable (Ljava/util/List;Lkage/crypto/stream/RandomAccessSource;J)Lkage/crypto/stream/SeekableDecrypt;
 	public static final fun decryptStream (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;)V
 	public static final fun encrypt (Ljava/util/List;Ljava/io/InputStream;)Lkage/format/AgeFile;
+	public static final fun encryptReader (Ljava/util/List;Ljava/io/InputStream;)Ljava/io/InputStream;
 	public static final fun encryptStream (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;Z)V
 	public static final fun encryptStream (Ljava/util/List;Ljava/io/OutputStream;Z)Ljava/io/OutputStream;
 	public static synthetic fun encryptStream$default (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;ZILjava/lang/Object;)V

--- a/api/kage.api
+++ b/api/kage.api
@@ -3,6 +3,7 @@ public final class kage/Age {
 	public static final fun decrypt (Ljava/util/List;Lkage/format/AgeFile;)Ljava/io/InputStream;
 	public static final fun decrypt (Lkage/Identity;Lkage/format/AgeFile;)Ljava/io/InputStream;
 	public static final fun decryptHeader ([BLjava/util/List;)[B
+	public static final fun decryptSeekable (Ljava/util/List;Lkage/crypto/stream/RandomAccessSource;J)Lkage/crypto/stream/SeekableDecrypt;
 	public static final fun decryptStream (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;)V
 	public static final fun encrypt (Ljava/util/List;Ljava/io/InputStream;)Lkage/format/AgeFile;
 	public static final fun encryptStream (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;Z)V
@@ -81,6 +82,21 @@ public final class kage/crypto/ssh/SshRsaRecipient : kage/Recipient {
 
 public final class kage/crypto/ssh/SshRsaRecipient$Companion {
 	public final fun parse (Ljava/lang/String;)Lkage/crypto/ssh/SshRsaRecipient;
+}
+
+public abstract interface class kage/crypto/stream/RandomAccessSource {
+	public static final field Companion Lkage/crypto/stream/RandomAccessSource$Companion;
+	public static fun of (Ljava/nio/channels/FileChannel;)Lkage/crypto/stream/RandomAccessSource;
+	public abstract fun readAt ([BIIJ)I
+}
+
+public final class kage/crypto/stream/RandomAccessSource$Companion {
+	public final fun of (Ljava/nio/channels/FileChannel;)Lkage/crypto/stream/RandomAccessSource;
+}
+
+public final class kage/crypto/stream/SeekableDecrypt {
+	public final fun getPlaintextSize ()J
+	public final fun readAt ([BJ)I
 }
 
 public final class kage/crypto/x25519/X25519 {

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -17,6 +17,8 @@ import kage.crypto.stream.ArmorInputStream
 import kage.crypto.stream.ArmorOutputStream
 import kage.crypto.stream.DecryptInputStream
 import kage.crypto.stream.EncryptOutputStream
+import kage.crypto.stream.RandomAccessSource
+import kage.crypto.stream.SeekableDecrypt
 import kage.errors.IncorrectHMACException
 import kage.errors.InvalidHMACHeaderException
 import kage.errors.InvalidNonceException
@@ -152,6 +154,45 @@ public object Age {
   @JvmStatic
   public fun decryptHeader(header: ByteArray, identities: List<Identity>): ByteArray =
     resolveFileKey(identities, AgeHeader.parse(ByteArrayInputStream(header).buffered()))
+
+  /**
+   * Opens an age file at [source] ([encryptedSize] bytes) for random access with one of
+   * [identities]. Unlike [decryptStream], [source] must be raw binary; armor is not handled.
+   *
+   * [encryptedSize] must be the exact length of the encrypted file, and [source] must not change
+   * for the lifetime of the returned [SeekableDecrypt]; both are trusted, not re-validated per
+   * read.
+   *
+   * This is a low-level method that most users won't need.
+   */
+  @JvmStatic
+  public fun decryptSeekable(
+    identities: List<Identity>,
+    source: RandomAccessSource,
+    encryptedSize: Long,
+  ): SeekableDecrypt {
+    val headerStream = RandomAccessSourceInputStream(source, encryptedSize).buffered()
+    val header = AgeHeader.parse(headerStream)
+    val fileKey = resolveFileKey(identities, header)
+
+    val nonce = ByteArray(STREAM_NONCE_SIZE)
+    var nonceOffset = 0
+    while (nonceOffset < STREAM_NONCE_SIZE) {
+      val read = headerStream.read(nonce, nonceOffset, STREAM_NONCE_SIZE - nonceOffset)
+      if (read == -1) throw InvalidNonceException("could not read payload nonce: stream truncated")
+      nonceOffset += read
+    }
+
+    // Re-serialize to measure the header length: BufferedInputStream's read-ahead may have
+    // already pulled past the header boundary, so the stream's own position isn't reliable.
+    val headerBytes = ByteArrayOutputStream()
+    headerBytes.bufferedWriter().use { writer -> header.write(writer) }
+    val payloadOffset = headerBytes.size().toLong() + STREAM_NONCE_SIZE
+    val payloadSize = encryptedSize - payloadOffset
+
+    val streamKey = Primitives.streamKey(fileKey, nonce)
+    return SeekableDecrypt(streamKey, source, payloadOffset, payloadSize)
+  }
 
   private fun encryptInternal(
     recipients: List<Recipient>,
@@ -312,5 +353,31 @@ public object Age {
     DecryptInputStream(streamKey, src).use { decrypted ->
       dstStream.use { dst -> decrypted.copyTo(dst) }
     }
+  }
+}
+
+/** Presents a [RandomAccessSource] as a plain sequential stream, bounded to [size] bytes. */
+private class RandomAccessSourceInputStream(
+  private val source: RandomAccessSource,
+  private val size: Long,
+) : InputStream() {
+  private var position = 0L
+
+  override fun read(): Int {
+    val single = ByteArray(1)
+    return if (read(single, 0, 1) <= 0) -1 else single[0].toInt() and 0xFF
+  }
+
+  override fun read(b: ByteArray, off: Int, len: Int): Int {
+    if (len == 0) return 0
+    if (position >= size) return -1
+    var n: Int
+    do {
+      val toRead = minOf(len.toLong(), size - position).toInt()
+      n = source.readAt(b, off, toRead, position)
+    } while (n == 0)
+    if (n < 0) return -1
+    position += n
+    return n
   }
 }

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -10,12 +10,15 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
+import java.io.SequenceInputStream
 import java.security.MessageDigest
 import java.security.SecureRandom
+import java.util.Collections
 import kage.crypto.scrypt.ScryptRecipient
 import kage.crypto.stream.ArmorInputStream
 import kage.crypto.stream.ArmorOutputStream
 import kage.crypto.stream.DecryptInputStream
+import kage.crypto.stream.EncryptInputStream
 import kage.crypto.stream.EncryptOutputStream
 import kage.crypto.stream.RandomAccessSource
 import kage.crypto.stream.SeekableDecrypt
@@ -89,6 +92,34 @@ public object Age {
     stream.use { output -> plainText.use { input -> input.copyTo(output) } }
 
     return AgeFile(header, out.toByteArray())
+  }
+
+  /**
+   * Returns a stream that encrypts [plainText] for [recipients] as it's read.
+   *
+   * Nothing is encrypted until the returned stream is read. Prefer [encryptStream] when writing to
+   * an [OutputStream] directly.
+   */
+  @JvmStatic
+  public fun encryptReader(recipients: List<Recipient>, plainText: InputStream): InputStream {
+    val (ageHeader, fileKey) = buildHeader(recipients)
+
+    val headerBytes = ByteArrayOutputStream()
+    headerBytes.bufferedWriter().use { writer -> ageHeader.write(writer) }
+
+    val nonce = ByteArray(STREAM_NONCE_SIZE)
+    SecureRandom().nextBytes(nonce)
+    val streamKey = Primitives.streamKey(fileKey, nonce)
+
+    return SequenceInputStream(
+      Collections.enumeration(
+        listOf(
+          ByteArrayInputStream(headerBytes.toByteArray()),
+          ByteArrayInputStream(nonce),
+          EncryptInputStream(streamKey, plainText),
+        )
+      )
+    )
   }
 
   /**
@@ -199,6 +230,26 @@ public object Age {
     dst: OutputStream,
     writeHeaders: Boolean = true,
   ): Pair<AgeHeader, OutputStream> {
+    val (ageHeader, fileKey) = buildHeader(recipients)
+
+    val nonce = ByteArray(STREAM_NONCE_SIZE)
+    SecureRandom().nextBytes(nonce)
+
+    if (writeHeaders) {
+      val writer = dst.bufferedWriter()
+      ageHeader.write(writer)
+      // Need to flush the wrapping stream before writing again to the underlying stream
+      writer.flush()
+    }
+
+    dst.write(nonce)
+
+    val streamKey = Primitives.streamKey(fileKey, nonce)
+
+    return Pair(ageHeader, EncryptOutputStream(streamKey, dst))
+  }
+
+  private fun buildHeader(recipients: List<Recipient>): Pair<AgeHeader, ByteArray> {
     if (recipients.isEmpty()) {
       throw NoRecipientsException("No recipients specified")
     }
@@ -221,24 +272,7 @@ public object Age {
       }
     }
 
-    // TODO: Check if we need a deep copy of stanzas here
-    val ageHeader = AgeHeader.withMac(stanzas, fileKey)
-
-    val nonce = ByteArray(STREAM_NONCE_SIZE)
-    SecureRandom().nextBytes(nonce)
-
-    if (writeHeaders) {
-      val writer = dst.bufferedWriter()
-      ageHeader.write(writer)
-      // Need to flush the wrapping stream before writing again to the underlying stream
-      writer.flush()
-    }
-
-    dst.write(nonce)
-
-    val streamKey = Primitives.streamKey(fileKey, nonce)
-
-    return Pair(ageHeader, EncryptOutputStream(streamKey, dst))
+    return Pair(AgeHeader.withMac(stanzas, fileKey), fileKey)
   }
 
   private fun wrapWithLabels(

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -206,13 +206,7 @@ public object Age {
     val header = AgeHeader.parse(headerStream)
     val fileKey = resolveFileKey(identities, header)
 
-    val nonce = ByteArray(STREAM_NONCE_SIZE)
-    var nonceOffset = 0
-    while (nonceOffset < STREAM_NONCE_SIZE) {
-      val read = headerStream.read(nonce, nonceOffset, STREAM_NONCE_SIZE - nonceOffset)
-      if (read == -1) throw InvalidNonceException("could not read payload nonce: stream truncated")
-      nonceOffset += read
-    }
+    val nonce = readPayloadNonce(headerStream)
 
     // Re-serialize to measure the header length: BufferedInputStream's read-ahead may have
     // already pulled past the header boundary, so the stream's own position isn't reliable.
@@ -349,6 +343,13 @@ public object Age {
     } else markSupportedStream
   }
 
+  private fun readPayloadNonce(stream: InputStream): ByteArray {
+    val nonce = ByteArray(STREAM_NONCE_SIZE)
+    if (stream.readFully(nonce) != nonce.size)
+      throw InvalidNonceException("could not read payload nonce: stream truncated")
+    return nonce
+  }
+
   private fun decryptInternal(identities: List<Identity>, ageFile: AgeFile): InputStream {
     val fileKey = resolveFileKey(identities, ageFile.header)
 
@@ -374,13 +375,7 @@ public object Age {
 
     val fileKey = resolveFileKey(identities, header)
 
-    val nonce = ByteArray(STREAM_NONCE_SIZE)
-    var nonceOffset = 0
-    while (nonceOffset < STREAM_NONCE_SIZE) {
-      val read = src.read(nonce, nonceOffset, STREAM_NONCE_SIZE - nonceOffset)
-      if (read == -1) throw InvalidNonceException("could not read payload nonce: stream truncated")
-      nonceOffset += read
-    }
+    val nonce = readPayloadNonce(src)
 
     val streamKey = Primitives.streamKey(fileKey, nonce)
 

--- a/src/kotlin/kage/crypto/stream/EncryptInputStream.kt
+++ b/src/kotlin/kage/crypto/stream/EncryptInputStream.kt
@@ -19,6 +19,7 @@ import kage.crypto.stream.Stream.setLastChunkFlag
 internal class EncryptInputStream(private val key: ByteArray, private val src: InputStream) :
   InputStream() {
   private val nonce = ByteArray(NONCE_LENGTH)
+  private val singleByte = ByteArray(1)
 
   // One byte past CHUNK_SIZE so a full read tells us whether more plaintext follows, without
   // which we can't know whether this chunk is the last one to encrypt.
@@ -31,9 +32,8 @@ internal class EncryptInputStream(private val key: ByteArray, private val src: I
   private var streamDone = false
 
   override fun read(): Int {
-    val b = ByteArray(1)
-    val n = read(b, 0, 1)
-    return if (n == -1) -1 else (b[0].toInt() and 0xff)
+    val n = read(singleByte, 0, 1)
+    return if (n == -1) -1 else (singleByte[0].toInt() and 0xff)
   }
 
   override fun read(b: ByteArray, off: Int, len: Int): Int {

--- a/src/kotlin/kage/crypto/stream/EncryptInputStream.kt
+++ b/src/kotlin/kage/crypto/stream/EncryptInputStream.kt
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.stream
+
+import java.io.InputStream
+import kage.crypto.stream.ChaCha20Poly1305.NONCE_LENGTH
+import kage.crypto.stream.EncryptOutputStream.Companion.CHUNK_SIZE
+import kage.crypto.stream.Stream.incNonce
+import kage.crypto.stream.Stream.setLastChunkFlag
+
+/**
+ * Reads plaintext from the underlying stream and provides encrypted data when calling `read`.
+ *
+ * This class is **not** thread safe.
+ */
+internal class EncryptInputStream(private val key: ByteArray, private val src: InputStream) :
+  InputStream() {
+  private val nonce = ByteArray(NONCE_LENGTH)
+
+  // One byte past CHUNK_SIZE so a full read tells us whether more plaintext follows, without
+  // which we can't know whether this chunk is the last one to encrypt.
+  private val buf = ByteArray(CHUNK_SIZE + 1)
+  private var bufSize = 0
+
+  private val encrypted = ByteArray(ChaCha20Poly1305.getEncryptOutputSize(CHUNK_SIZE))
+  private var encryptedSize = 0
+  private var encryptedOffset = 0
+  private var streamDone = false
+
+  override fun read(): Int {
+    val b = ByteArray(1)
+    val n = read(b, 0, 1)
+    return if (n == -1) -1 else (b[0].toInt() and 0xff)
+  }
+
+  override fun read(b: ByteArray, off: Int, len: Int): Int {
+    if (len == 0) return 0
+    if (encryptedOffset == encryptedSize) {
+      if (streamDone) return -1
+      encryptChunk()
+    }
+    val n = minOf(len, encryptedSize - encryptedOffset)
+    encrypted.copyInto(b, off, encryptedOffset, encryptedOffset + n)
+    encryptedOffset += n
+    return n
+  }
+
+  private fun encryptChunk() {
+    fillBuffer()
+
+    val last = bufSize <= CHUNK_SIZE
+    val chunkSize = if (last) bufSize else CHUNK_SIZE
+    if (last) {
+      setLastChunkFlag(nonce)
+      streamDone = true
+    }
+
+    encryptedSize = ChaCha20Poly1305.encrypt(key, nonce, buf, 0, chunkSize, encrypted)
+    encryptedOffset = 0
+    incNonce(nonce)
+
+    if (!last) {
+      // Carry the peeked byte into the next chunk.
+      buf[0] = buf[CHUNK_SIZE]
+      bufSize = 1
+    }
+  }
+
+  private fun fillBuffer() {
+    while (bufSize < buf.size) {
+      val n = src.read(buf, bufSize, buf.size - bufSize)
+      if (n == -1) return
+      bufSize += n
+    }
+  }
+
+  override fun close() {
+    src.close()
+  }
+}

--- a/src/kotlin/kage/crypto/stream/RandomAccessSource.kt
+++ b/src/kotlin/kage/crypto/stream/RandomAccessSource.kt
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.stream
+
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+
+/**
+ * A byte source readable at an arbitrary offset without disturbing any position state, kage's
+ * equivalent of Go's `io.ReaderAt`. Implementations must be thread safe. Mirrors
+ * [FileChannel.read]'s contract: a call may return fewer than [length] bytes even mid-source, so
+ * callers needing an exact count must loop.
+ */
+public fun interface RandomAccessSource {
+  /**
+   * Reads up to [length] bytes starting at [sourceOffset] into [dst] starting at [destOffset].
+   * Returns the number of bytes actually read, or -1 if [sourceOffset] is at or past the end.
+   */
+  public fun readAt(dst: ByteArray, destOffset: Int, length: Int, sourceOffset: Long): Int
+
+  public companion object {
+    /** Wraps a [FileChannel]; its positional [FileChannel.read] is already thread safe. */
+    @JvmStatic
+    public fun of(channel: FileChannel): RandomAccessSource =
+      RandomAccessSource { dst, destOffset, length, sourceOffset ->
+        channel.read(ByteBuffer.wrap(dst, destOffset, length), sourceOffset)
+      }
+  }
+}

--- a/src/kotlin/kage/crypto/stream/SeekableDecrypt.kt
+++ b/src/kotlin/kage/crypto/stream/SeekableDecrypt.kt
@@ -117,13 +117,16 @@ internal constructor(
 
     fun encryptedChunkCount(payloadSize: Long): Long {
       if (payloadSize < 0) throw StreamException("invalid encrypted payload size: $payloadSize")
-      val chunks = (payloadSize + ENC_CHUNK_SIZE - 1) / ENC_CHUNK_SIZE
+      val chunks = ceilingDivide(payloadSize, ENC_CHUNK_SIZE)
+      if (chunks <= 0) throw StreamException("invalid encrypted payload size: $payloadSize")
       val plaintextSize = payloadSize - chunks * MAC_SIZE
-      var expectedChunks = (plaintextSize + CHUNK_SIZE - 1) / CHUNK_SIZE
-      if (plaintextSize == 0L) expectedChunks = 1
+      val expectedChunks = if (plaintextSize == 0L) 1 else ceilingDivide(plaintextSize, CHUNK_SIZE)
       if (expectedChunks != chunks)
         throw StreamException("invalid encrypted payload size: $payloadSize")
       return chunks
     }
+
+    fun ceilingDivide(dividend: Long, divisor: Int): Long =
+      dividend / divisor + if (dividend % divisor == 0L) 0 else 1
   }
 }

--- a/src/kotlin/kage/crypto/stream/SeekableDecrypt.kt
+++ b/src/kotlin/kage/crypto/stream/SeekableDecrypt.kt
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.stream
+
+import java.util.concurrent.atomic.AtomicReference
+import kage.crypto.stream.ChaCha20Poly1305.MAC_SIZE
+import kage.crypto.stream.ChaCha20Poly1305.NONCE_LENGTH
+import kage.crypto.stream.EncryptOutputStream.Companion.CHUNK_SIZE
+import kage.crypto.stream.Stream.setLastChunkFlag
+import kage.errors.StreamException
+
+/**
+ * Random access into an age STREAM payload: [readAt] can decrypt any offset directly, without
+ * reading everything before it first, unlike [DecryptInputStream]. Construct with
+ * [kage.Age.decryptSeekable].
+ *
+ * The most recently decrypted chunk is cached, and `readAt` is safe to call concurrently.
+ */
+public class SeekableDecrypt
+internal constructor(
+  private val key: ByteArray,
+  private val source: RandomAccessSource,
+  private val payloadOffset: Long,
+  private val payloadSize: Long,
+) {
+  private val chunks: Long = encryptedChunkCount(payloadSize)
+
+  /** Size of the decrypted plaintext, in bytes. */
+  public val plaintextSize: Long = payloadSize - chunks * MAC_SIZE
+
+  private class CachedChunk(val chunkIndex: Long, val plaintext: ByteArray)
+
+  private val cache = AtomicReference<CachedChunk>()
+
+  init {
+    // Authenticates the final chunk up front, so a truncated payload fails immediately rather
+    // than only once a read reaches the end.
+    cache.set(decryptChunk(chunks - 1))
+  }
+
+  /**
+   * Reads plaintext starting at [offset] into [dst]. Returns the number of bytes actually read,
+   * which is less than `dst.size` only at the end of the plaintext.
+   */
+  public fun readAt(dst: ByteArray, offset: Long): Int {
+    if (offset < 0 || offset > plaintextSize)
+      throw StreamException("offset out of range [0:$plaintextSize]: $offset")
+    if (dst.isEmpty() || offset == plaintextSize) return 0
+
+    var written = 0
+    var pos = offset
+    while (written < dst.size && pos < plaintextSize) {
+      val chunkIndex = pos / CHUNK_SIZE
+      val cached = cache.get()
+      val plaintext =
+        if (cached != null && cached.chunkIndex == chunkIndex) {
+          cached.plaintext
+        } else {
+          decryptChunk(chunkIndex).also { cache.set(it) }.plaintext
+        }
+
+      val chunkOffset = (pos - chunkIndex * CHUNK_SIZE).toInt()
+      val copyLen = minOf(plaintext.size - chunkOffset, dst.size - written)
+      plaintext.copyInto(dst, written, chunkOffset, chunkOffset + copyLen)
+      written += copyLen
+      pos += copyLen
+    }
+    return written
+  }
+
+  private fun decryptChunk(chunkIndex: Long): CachedChunk {
+    val chunkOffset = chunkIndex * ENC_CHUNK_SIZE
+    val chunkSize = minOf(payloadSize - chunkOffset, ENC_CHUNK_SIZE.toLong()).toInt()
+    val encrypted = ByteArray(chunkSize)
+    readFullyAt(encrypted, chunkOffset)
+
+    val nonce = nonceForChunk(chunkIndex)
+    if (chunkIndex == chunks - 1) setLastChunkFlag(nonce)
+
+    val plaintext = ByteArray(chunkSize - MAC_SIZE)
+    val decryptedSize =
+      try {
+        ChaCha20Poly1305.decrypt(key, nonce, encrypted, 0, chunkSize, plaintext, 0)
+      } catch (e: Exception) {
+        throw StreamException("failed to decrypt and authenticate chunk at offset $chunkOffset", e)
+      }
+    if (decryptedSize != plaintext.size)
+      throw StreamException("short chunk decrypt at offset $chunkOffset: $decryptedSize")
+    return CachedChunk(chunkIndex, plaintext)
+  }
+
+  private fun readFullyAt(dst: ByteArray, sourceOffset: Long) {
+    var filled = 0
+    while (filled < dst.size) {
+      val n = source.readAt(dst, filled, dst.size - filled, payloadOffset + sourceOffset + filled)
+      if (n <= 0)
+        throw StreamException(
+          "unexpected end of source while reading chunk at offset $sourceOffset"
+        )
+      filled += n
+    }
+  }
+
+  private companion object {
+    const val ENC_CHUNK_SIZE = CHUNK_SIZE + MAC_SIZE
+
+    fun nonceForChunk(chunkIndex: Long): ByteArray {
+      val nonce = ByteArray(NONCE_LENGTH)
+      for (i in 0 until 8) {
+        nonce[3 + i] = (chunkIndex ushr (8 * (7 - i)) and 0xFF).toByte()
+      }
+      return nonce
+    }
+
+    fun encryptedChunkCount(payloadSize: Long): Long {
+      if (payloadSize < 0) throw StreamException("invalid encrypted payload size: $payloadSize")
+      val chunks = (payloadSize + ENC_CHUNK_SIZE - 1) / ENC_CHUNK_SIZE
+      val plaintextSize = payloadSize - chunks * MAC_SIZE
+      var expectedChunks = (plaintextSize + CHUNK_SIZE - 1) / CHUNK_SIZE
+      if (plaintextSize == 0L) expectedChunks = 1
+      if (expectedChunks != chunks)
+        throw StreamException("invalid encrypted payload size: $payloadSize")
+      return chunks
+    }
+  }
+}

--- a/src/test/kotlin/kage/crypto/stream/EncryptInputStreamTest.kt
+++ b/src/test/kotlin/kage/crypto/stream/EncryptInputStreamTest.kt
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.stream
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import kage.Age
+import kage.crypto.x25519.X25519Identity
+import org.junit.jupiter.api.Test
+
+class EncryptInputStreamTest {
+  private val identity = X25519Identity.`new`()
+
+  /**
+   * Never returns more than one byte per [read] call, forcing [EncryptInputStream]'s buffer-fill
+   * loop to run more than once per chunk instead of getting lucky with a single full read.
+   */
+  private class ShortReadInputStream(private val delegate: InputStream) : InputStream() {
+    override fun read(): Int = delegate.read()
+
+    override fun read(b: ByteArray, off: Int, len: Int): Int {
+      if (len == 0) return 0
+      val next = delegate.read()
+      if (next == -1) return -1
+      b[off] = next.toByte()
+      return 1
+    }
+  }
+
+  private fun decrypt(ciphertext: ByteArray): ByteArray {
+    val out = ByteArrayOutputStream()
+    Age.decryptStream(listOf(identity), ByteArrayInputStream(ciphertext), out)
+    return out.toByteArray()
+  }
+
+  // Chunk size is 64 KiB; these sizes exercise empty, sub-chunk, exactly-one-chunk, one-chunk-
+  // plus-a-byte, and multi-chunk-with-a-partial-final-chunk payloads.
+  private val sizes = listOf(0, 1, 100, 65536, 65537, 65536 * 3 + 42)
+
+  @Test
+  fun encryptReader_roundTripsAtEveryChunkBoundary() {
+    for (size in sizes) {
+      val plaintext = ByteArray(size) { (it % 251).toByte() }
+      val ciphertext =
+        Age.encryptReader(listOf(identity.recipient()), ByteArrayInputStream(plaintext))
+          .readAllBytes()
+
+      assertThat(decrypt(ciphertext)).isEqualTo(plaintext)
+    }
+  }
+
+  @Test
+  fun encryptReader_survivesShortReadsFromTheSource() {
+    val plaintext = ByteArray(EncryptOutputStream.CHUNK_SIZE + 137) { (it % 251).toByte() }
+    val src = ShortReadInputStream(ByteArrayInputStream(plaintext))
+
+    val ciphertext = Age.encryptReader(listOf(identity.recipient()), src).readAllBytes()
+
+    assertThat(decrypt(ciphertext)).isEqualTo(plaintext)
+  }
+
+  @Test
+  fun encryptReader_closingTheStreamClosesTheSource() {
+    var closed = false
+    val src =
+      object : InputStream() {
+        override fun read() = -1
+
+        override fun close() {
+          closed = true
+        }
+      }
+
+    Age.encryptReader(listOf(identity.recipient()), src).close()
+
+    assertThat(closed).isTrue()
+  }
+}

--- a/src/test/kotlin/kage/crypto/stream/SeekableDecryptTest.kt
+++ b/src/test/kotlin/kage/crypto/stream/SeekableDecryptTest.kt
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage.crypto.stream
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.RandomAccessFile
+import java.nio.file.Files
+import kage.Age
+import kage.crypto.x25519.X25519Identity
+import kage.errors.StreamException
+import kage.errors.X25519IdentityException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SeekableDecryptTest {
+  private val identity = X25519Identity.`new`()
+
+  // A full standalone age file, not Age.encrypt(...).body: that splits the header into a
+  // separate field instead of prefixing it, so it isn't what decryptSeekable expects on disk.
+  private fun encrypt(plaintext: ByteArray): ByteArray {
+    val out = ByteArrayOutputStream()
+    Age.encryptStream(listOf(identity.recipient()), ByteArrayInputStream(plaintext), out)
+    return out.toByteArray()
+  }
+
+  private fun byteArraySource(data: ByteArray) =
+    RandomAccessSource { dst, destOffset, length, sourceOffset ->
+      if (sourceOffset >= data.size) {
+        -1
+      } else {
+        val n = minOf(length.toLong(), data.size - sourceOffset).toInt()
+        data.copyInto(dst, destOffset, sourceOffset.toInt(), sourceOffset.toInt() + n)
+        n
+      }
+    }
+
+  private fun readAll(decrypted: SeekableDecrypt): ByteArray {
+    val out = ByteArray(decrypted.plaintextSize.toInt())
+    val buf = ByteArray(1024)
+    var offset = 0L
+    while (offset < out.size) {
+      val n = decrypted.readAt(buf, offset)
+      if (n <= 0) break
+      buf.copyInto(out, offset.toInt(), 0, n)
+      offset += n
+    }
+    return out
+  }
+
+  // Chunk size is 64 KiB; these sizes exercise empty, sub-chunk, exactly-one-chunk, one-chunk-
+  // plus-a-byte, and multi-chunk-with-a-partial-final-chunk payloads.
+  private val sizes = listOf(0, 1, 100, 65536, 65537, 65536 * 3 + 42)
+
+  @Test
+  fun readAt_matchesTheOriginalPlaintextAtEveryChunkBoundary() {
+    for (size in sizes) {
+      val plaintext = ByteArray(size) { (it % 251).toByte() }
+      val ciphertext = encrypt(plaintext)
+      val decrypted =
+        Age.decryptSeekable(listOf(identity), byteArraySource(ciphertext), ciphertext.size.toLong())
+
+      assertThat(decrypted.plaintextSize).isEqualTo(size.toLong())
+      assertThat(readAll(decrypted)).isEqualTo(plaintext)
+    }
+  }
+
+  @Test
+  fun readAt_returnsTheRightBytesForAnArbitraryMidFileOffset() {
+    val plaintext = ByteArray(65536 * 3 + 42) { (it % 251).toByte() }
+    val ciphertext = encrypt(plaintext)
+    val decrypted =
+      Age.decryptSeekable(listOf(identity), byteArraySource(ciphertext), ciphertext.size.toLong())
+
+    // Straddles a chunk boundary: starts in chunk 0, the requested length runs into chunk 1.
+    val offset = 65536L - 10
+    val buf = ByteArray(20)
+    val n = decrypted.readAt(buf, offset)
+
+    assertThat(n).isEqualTo(20)
+    assertThat(buf).isEqualTo(plaintext.copyOfRange(offset.toInt(), offset.toInt() + 20))
+  }
+
+  @Test
+  fun readAt_worksAgainstARealFileChannel() {
+    val plaintext = ByteArray(65536 + 500) { (it % 251).toByte() }
+    val ciphertext = encrypt(plaintext)
+    val file = Files.createTempFile("kage-seekable-decrypt-test", ".age")
+    try {
+      Files.write(file, ciphertext)
+      RandomAccessFile(file.toFile(), "r").use { raf ->
+        val source = RandomAccessSource.of(raf.channel)
+        val decrypted = Age.decryptSeekable(listOf(identity), source, ciphertext.size.toLong())
+        assertThat(readAll(decrypted)).isEqualTo(plaintext)
+      }
+    } finally {
+      Files.deleteIfExists(file)
+    }
+  }
+
+  @Test
+  fun decryptSeekable_rejectsATruncatedFile() {
+    val plaintext = ByteArray(65536 + 500) { (it % 251).toByte() }
+    val ciphertext = encrypt(plaintext)
+    val truncated = ciphertext.copyOfRange(0, ciphertext.size - 5)
+
+    assertThrows<StreamException> {
+      Age.decryptSeekable(listOf(identity), byteArraySource(truncated), truncated.size.toLong())
+    }
+  }
+
+  @Test
+  fun decryptSeekable_rejectsGarbageAppendedAfterTheLastChunk() {
+    val plaintext = ByteArray(65536 + 500) { (it % 251).toByte() }
+    val ciphertext = encrypt(plaintext) + byteArrayOf(1, 2, 3, 4)
+
+    assertThrows<StreamException> {
+      Age.decryptSeekable(listOf(identity), byteArraySource(ciphertext), ciphertext.size.toLong())
+    }
+  }
+
+  @Test
+  fun seekableDecrypt_rejectsANegativePayloadSize() {
+    val key = ByteArray(ChaCha20Poly1305.KEY_LENGTH)
+
+    assertThrows<StreamException> { SeekableDecrypt(key, byteArraySource(ByteArray(0)), 0L, -1L) }
+  }
+
+  @Test
+  fun decryptSeekable_rejectsTheWrongIdentity() {
+    val ciphertext = encrypt("hello".toByteArray())
+    val wrongIdentity = X25519Identity.`new`()
+
+    // X25519 stanzas carry no fingerprint hint (recipient-anonymous by design), so a wrong key
+    // fails at AEAD authentication rather than a fast fingerprint mismatch.
+    assertThrows<X25519IdentityException> {
+      Age.decryptSeekable(
+        listOf(wrongIdentity),
+        byteArraySource(ciphertext),
+        ciphertext.size.toLong(),
+      )
+    }
+  }
+
+  @Test
+  fun readAt_rejectsAnOffsetPastTheEnd() {
+    val ciphertext = encrypt("hello".toByteArray())
+    val decrypted =
+      Age.decryptSeekable(listOf(identity), byteArraySource(ciphertext), ciphertext.size.toLong())
+
+    assertThrows<StreamException> { decrypted.readAt(ByteArray(1), decrypted.plaintextSize + 1) }
+  }
+}

--- a/src/test/kotlin/kage/crypto/stream/SeekableDecryptTest.kt
+++ b/src/test/kotlin/kage/crypto/stream/SeekableDecryptTest.kt
@@ -131,6 +131,16 @@ class SeekableDecryptTest {
   }
 
   @Test
+  fun seekableDecrypt_rejectsPayloadSizesNearLongMaxWithoutArithmeticOverflow() {
+    val key = ByteArray(ChaCha20Poly1305.KEY_LENGTH)
+    val payloadSize = Long.MAX_VALUE - 200
+
+    assertThrows<StreamException> {
+      SeekableDecrypt(key, byteArraySource(ByteArray(0)), 0L, payloadSize)
+    }
+  }
+
+  @Test
   fun decryptSeekable_rejectsTheWrongIdentity() {
     val ciphertext = encrypt("hello".toByteArray())
     val wrongIdentity = X25519Identity.`new`()


### PR DESCRIPTION
Two pieces of age's stream API kage was missing: `DecryptReaderAt` (jump to any offset in an encrypted file without decrypting from the start) and `EncryptReader` (the pull-based mirror of the existing push-based `encryptStream`).

`Age.decryptSeekable(identities, source: RandomAccessSource, encryptedSize)` returns a `SeekableDecrypt` whose `readAt(dst, offset)` decrypts directly at any offset. Useful for things like a zip archive stored inside an age file, or FUSE-mounted encrypted content. `RandomAccessSource` is kage's own `io.ReaderAt` equivalent (with a `FileChannel` adapter), kept generic rather than hardcoded to a file type, matching Go. The last chunk is authenticated at construction so truncation fails immediately, and the most recently decrypted chunk is cached behind an `AtomicReference` so `readAt` is thread safe, same as Go's version.

`Age.encryptReader(recipients, plainText)` encrypts as you read from it instead of requiring a write loop. It uses the same over-read-by-one-byte trick as Go to detect the last chunk without knowing `plainText`'s length up front.

Tested at every chunk-size boundary, a real `FileChannel`-backed round trip, short-read survival on the source stream, and rejection of truncation, trailing garbage, wrong identity, and bad payload sizes.

Notes for review:
- New public API: `Age.decryptSeekable`, `Age.encryptReader`, `RandomAccessSource`, `SeekableDecrypt`. In the `kage.api` diff.
- Verified with `./gradlew test checkKotlinAbi animalsnifferMain spotlessCheck`.
