### PR TITLE
feat: add Age.parseIdentities/parseRecipients

### DIFF
--- a/api/kage.api
+++ b/api/kage.api
@@ -12,6 +12,8 @@ public final class kage/Age {
 	public static synthetic fun encryptStream$default (Ljava/util/List;Ljava/io/InputStream;Ljava/io/OutputStream;ZILjava/lang/Object;)V
 	public static synthetic fun encryptStream$default (Ljava/util/List;Ljava/io/OutputStream;ZILjava/lang/Object;)Ljava/io/OutputStream;
 	public static final fun extractHeader (Ljava/io/InputStream;)[B
+	public static final fun parseIdentities (Ljava/io/BufferedReader;)Ljava/util/List;
+	public static final fun parseRecipients (Ljava/io/BufferedReader;)Ljava/util/List;
 }
 
 public abstract interface class kage/Identity {
@@ -240,6 +242,13 @@ public abstract class kage/errors/InvalidIdentityException : kage/errors/CryptoE
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class kage/errors/InvalidIdentityFileException : kage/errors/ParseException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class kage/errors/InvalidNonceException : kage/errors/ParseException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
@@ -248,6 +257,13 @@ public final class kage/errors/InvalidNonceException : kage/errors/ParseExceptio
 }
 
 public final class kage/errors/InvalidRecipientException : kage/errors/ParseException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class kage/errors/InvalidRecipientFileException : kage/errors/ParseException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -6,6 +6,7 @@
 package kage
 
 import java.io.BufferedInputStream
+import java.io.BufferedReader
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
@@ -14,6 +15,8 @@ import java.io.SequenceInputStream
 import java.security.MessageDigest
 import java.security.SecureRandom
 import java.util.Collections
+import kage.crypto.mlkem.MlKem768X25519Identity
+import kage.crypto.mlkem.MlKem768X25519Recipient
 import kage.crypto.scrypt.ScryptRecipient
 import kage.crypto.stream.ArmorInputStream
 import kage.crypto.stream.ArmorOutputStream
@@ -22,10 +25,14 @@ import kage.crypto.stream.EncryptInputStream
 import kage.crypto.stream.EncryptOutputStream
 import kage.crypto.stream.RandomAccessSource
 import kage.crypto.stream.SeekableDecrypt
+import kage.crypto.x25519.X25519Identity
+import kage.crypto.x25519.X25519Recipient
 import kage.errors.IncorrectHMACException
 import kage.errors.IncorrectIdentityException
 import kage.errors.InvalidHMACHeaderException
+import kage.errors.InvalidIdentityFileException
 import kage.errors.InvalidNonceException
+import kage.errors.InvalidRecipientFileException
 import kage.errors.InvalidScryptRecipientException
 import kage.errors.NoIdentitiesException
 import kage.errors.NoRecipientsException
@@ -40,6 +47,7 @@ public object Age {
   internal const val FILE_KEY_SIZE: Int = 16
   private const val STREAM_NONCE_SIZE = 16
   private const val HMAC_SIZE = 32
+  private const val KEY_FILE_SIZE_LIMIT = 1 shl 24 // 16 MiB
 
   /**
    * Starts encrypting data for [recipients] to [outputStream].
@@ -218,6 +226,52 @@ public object Age {
 
     val streamKey = Primitives.streamKey(fileKey, nonce)
     return SeekableDecrypt(streamKey, source, payloadOffset, payloadSize)
+  }
+
+  /** Parses [X25519Identity]/[MlKem768X25519Identity] lines from [reader], one per line. */
+  @JvmStatic
+  public fun parseIdentities(reader: BufferedReader): List<Identity> {
+    val identities = mutableListOf<Identity>()
+    var bytesRead = 0L
+    for (rawLine in reader.lineSequence()) {
+      bytesRead += rawLine.length + 1
+      if (bytesRead > KEY_FILE_SIZE_LIMIT)
+        throw InvalidIdentityFileException("identities file exceeds the 16 MiB size limit")
+      val line = rawLine.trim()
+      if (line.isEmpty() || line.startsWith("#")) continue
+      identities.add(
+        when {
+          line.startsWith("AGE-SECRET-KEY-1") -> X25519Identity.decode(line)
+          line.startsWith("AGE-SECRET-KEY-PQ-1") -> MlKem768X25519Identity.decode(line)
+          else -> throw InvalidIdentityFileException("unknown identity type: $line")
+        }
+      )
+    }
+    if (identities.isEmpty()) throw InvalidIdentityFileException("no identities found")
+    return identities
+  }
+
+  /** Parses [X25519Recipient]/[MlKem768X25519Recipient] lines from [reader], one per line. */
+  @JvmStatic
+  public fun parseRecipients(reader: BufferedReader): List<Recipient> {
+    val recipients = mutableListOf<Recipient>()
+    var bytesRead = 0L
+    for (rawLine in reader.lineSequence()) {
+      bytesRead += rawLine.length + 1
+      if (bytesRead > KEY_FILE_SIZE_LIMIT)
+        throw InvalidRecipientFileException("recipients file exceeds the 16 MiB size limit")
+      val line = rawLine.trim()
+      if (line.isEmpty() || line.startsWith("#")) continue
+      recipients.add(
+        when {
+          line.startsWith("age1pq1") -> MlKem768X25519Recipient.decode(line)
+          line.startsWith("age1") -> X25519Recipient.decode(line)
+          else -> throw InvalidRecipientFileException("unknown recipient type: $line")
+        }
+      )
+    }
+    if (recipients.isEmpty()) throw InvalidRecipientFileException("no recipients found")
+    return recipients
   }
 
   private fun encryptInternal(

--- a/src/kotlin/kage/Age.kt
+++ b/src/kotlin/kage/Age.kt
@@ -39,6 +39,7 @@ import kage.errors.NoRecipientsException
 import kage.errors.ScryptIdentityException
 import kage.format.AgeFile
 import kage.format.AgeHeader
+import kage.format.AgeKeyFile
 import kage.format.AgeStanza
 import kage.utils.readFully
 
@@ -48,6 +49,13 @@ public object Age {
   private const val STREAM_NONCE_SIZE = 16
   private const val HMAC_SIZE = 32
   private const val KEY_FILE_SIZE_LIMIT = 1 shl 24 // 16 MiB
+  private const val BECH32_SEPARATOR = "1"
+  private const val X25519_IDENTITY_PREFIX = AgeKeyFile.AGE_SECRET_KEY_PREFIX + BECH32_SEPARATOR
+  private const val MLKEM768_X25519_IDENTITY_PREFIX =
+    MlKem768X25519Identity.AGE_SECRET_KEY_PQ_PREFIX + BECH32_SEPARATOR
+  private const val X25519_RECIPIENT_PREFIX = AgeKeyFile.AGE_PUBLIC_KEY_PREFIX + BECH32_SEPARATOR
+  private const val MLKEM768_X25519_RECIPIENT_PREFIX =
+    MlKem768X25519Recipient.AGE_PUBLIC_KEY_PQ_PREFIX + BECH32_SEPARATOR
 
   /**
    * Starts encrypting data for [recipients] to [outputStream].
@@ -241,8 +249,8 @@ public object Age {
       if (line.isEmpty() || line.startsWith("#")) continue
       identities.add(
         when {
-          line.startsWith("AGE-SECRET-KEY-1") -> X25519Identity.decode(line)
-          line.startsWith("AGE-SECRET-KEY-PQ-1") -> MlKem768X25519Identity.decode(line)
+          line.startsWith(X25519_IDENTITY_PREFIX) -> X25519Identity.decode(line)
+          line.startsWith(MLKEM768_X25519_IDENTITY_PREFIX) -> MlKem768X25519Identity.decode(line)
           else -> throw InvalidIdentityFileException("unknown identity type: $line")
         }
       )
@@ -264,8 +272,8 @@ public object Age {
       if (line.isEmpty() || line.startsWith("#")) continue
       recipients.add(
         when {
-          line.startsWith("age1pq1") -> MlKem768X25519Recipient.decode(line)
-          line.startsWith("age1") -> X25519Recipient.decode(line)
+          line.startsWith(MLKEM768_X25519_RECIPIENT_PREFIX) -> MlKem768X25519Recipient.decode(line)
+          line.startsWith(X25519_RECIPIENT_PREFIX) -> X25519Recipient.decode(line)
           else -> throw InvalidRecipientFileException("unknown recipient type: $line")
         }
       )

--- a/src/kotlin/kage/errors/ParseException.kt
+++ b/src/kotlin/kage/errors/ParseException.kt
@@ -57,3 +57,13 @@ constructor(message: String? = null, cause: Throwable? = null) : ParseException(
 public class InvalidNonceException
 @JvmOverloads
 constructor(message: String? = null, cause: Throwable? = null) : ParseException(message, cause)
+
+/** Raised by [kage.Age.parseIdentities] on an unrecognized line or an empty identities file. */
+public class InvalidIdentityFileException
+@JvmOverloads
+constructor(message: String? = null, cause: Throwable? = null) : ParseException(message, cause)
+
+/** Raised by [kage.Age.parseRecipients] on an unrecognized line or an empty recipients file. */
+public class InvalidRecipientFileException
+@JvmOverloads
+constructor(message: String? = null, cause: Throwable? = null) : ParseException(message, cause)

--- a/src/test/kotlin/AgeParseTest.kt
+++ b/src/test/kotlin/AgeParseTest.kt
@@ -50,6 +50,14 @@ class AgeParseTest {
   }
 
   @Test
+  fun parseKeyFiles_rejectInputOverTheCharacterLimit() {
+    val overLimitComment = "#${"x".repeat(16 * 1024 * 1024)}"
+
+    assertThrows<InvalidIdentityFileException> { Age.parseIdentities(reader(overLimitComment)) }
+    assertThrows<InvalidRecipientFileException> { Age.parseRecipients(reader(overLimitComment)) }
+  }
+
+  @Test
   fun parseIdentities_rejectsAnEmptyFile() {
     assertThrows<InvalidIdentityFileException> { Age.parseIdentities(reader("# only a comment")) }
   }

--- a/src/test/kotlin/AgeParseTest.kt
+++ b/src/test/kotlin/AgeParseTest.kt
@@ -79,7 +79,16 @@ class AgeParseTest {
   fun parseRecipients_recognizesX25519AndHybridPqRecipients() {
     val x25519 = X25519Identity.new().recipient()
     val hybrid = MlKem768X25519Identity.new().recipient()
-    val file = "${x25519.encodeToString()}\n${hybrid.encodeToString()}"
+    val file =
+      """
+
+      # X25519 recipient
+      ${x25519.encodeToString()}
+
+      # Hybrid post-quantum recipient
+      ${hybrid.encodeToString()}
+      """
+        .trimIndent()
 
     val recipients = Age.parseRecipients(reader(file))
 

--- a/src/test/kotlin/AgeParseTest.kt
+++ b/src/test/kotlin/AgeParseTest.kt
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2022 The kage Authors. All rights reserved. Use of this source code is governed by
+ * either an Apache 2.0 or MIT license at your discretion, that can be found in the LICENSE-APACHE
+ * or LICENSE-MIT files respectively.
+ */
+package kage
+
+import com.google.common.truth.Truth.assertThat
+import java.io.BufferedReader
+import java.io.StringReader
+import kage.crypto.mlkem.MlKem768X25519Identity
+import kage.crypto.mlkem.MlKem768X25519Recipient
+import kage.crypto.x25519.X25519Identity
+import kage.crypto.x25519.X25519Recipient
+import kage.errors.InvalidIdentityFileException
+import kage.errors.InvalidRecipientFileException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AgeParseTest {
+  private fun reader(text: String): BufferedReader = BufferedReader(StringReader(text))
+
+  @Test
+  fun parseIdentities_skipsCommentsAndBlankLines() {
+    val file =
+      """
+
+      # this is a comment
+      # AGE-SECRET-KEY-1705XN76M8EYQ8M9PY4E2G3KA8DN7NSCGT3V4HMN20H3GCX4AS6HSSTG8D3
+      #
+
+      AGE-SECRET-KEY-1D6K0SGAX3NU66R4GYFZY0UQWCLM3UUSF3CXLW4KXZM342WQSJ82QKU59QJ
+      AGE-SECRET-KEY-19WUMFE89H3928FRJ5U3JYRNHM6CERQGKSQ584AQ8QY7T7R09D32SWE4DYH
+      """
+        .trimIndent()
+
+    assertThat(Age.parseIdentities(reader(file))).hasSize(2)
+  }
+
+  @Test
+  fun parseIdentities_rejectsAMalformedIdentity() {
+    val file =
+      """
+      AGE-SECRET-KEY-1705XN76M8EYQ8M9PY4E2G3KA8DN7NSCGT3V4HMN20H3GCX4AS6HSSTG8D3
+      AGE-SECRET-KEY--1D6K0SGAX3NU66R4GYFZY0UQWCLM3UUSF3CXLW4KXZM342WQSJ82QKU59Q
+      """
+        .trimIndent()
+
+    assertThrows<InvalidIdentityFileException> { Age.parseIdentities(reader(file)) }
+  }
+
+  @Test
+  fun parseIdentities_rejectsAnEmptyFile() {
+    assertThrows<InvalidIdentityFileException> { Age.parseIdentities(reader("# only a comment")) }
+  }
+
+  @Test
+  fun parseIdentities_recognizesHybridPqIdentities() {
+    val x25519 = X25519Identity.new()
+    val hybrid = MlKem768X25519Identity.new()
+    val file = "${x25519.encodeToString()}\n${hybrid.encodeToString()}"
+
+    val identities = Age.parseIdentities(reader(file))
+
+    assertThat(identities).hasSize(2)
+    assertThat(identities[0]).isInstanceOf(X25519Identity::class.java)
+    assertThat(identities[1]).isInstanceOf(MlKem768X25519Identity::class.java)
+  }
+
+  @Test
+  fun parseRecipients_recognizesX25519AndHybridPqRecipients() {
+    val x25519 = X25519Identity.new().recipient()
+    val hybrid = MlKem768X25519Identity.new().recipient()
+    val file = "${x25519.encodeToString()}\n${hybrid.encodeToString()}"
+
+    val recipients = Age.parseRecipients(reader(file))
+
+    assertThat(recipients).hasSize(2)
+    assertThat(recipients[0]).isInstanceOf(X25519Recipient::class.java)
+    assertThat(recipients[1]).isInstanceOf(MlKem768X25519Recipient::class.java)
+  }
+
+  @Test
+  fun parseRecipients_rejectsAnUnknownLine() {
+    assertThrows<InvalidRecipientFileException> {
+      Age.parseRecipients(reader("not-a-recipient"))
+    }
+  }
+
+  @Test
+  fun parseRecipients_rejectsAnEmptyFile() {
+    assertThrows<InvalidRecipientFileException> { Age.parseRecipients(reader("")) }
+  }
+}

--- a/src/test/kotlin/AgeParseTest.kt
+++ b/src/test/kotlin/AgeParseTest.kt
@@ -99,8 +99,10 @@ class AgeParseTest {
 
   @Test
   fun parseRecipients_rejectsAnUnknownLine() {
+    val validRecipient = X25519Identity.new().recipient().encodeToString()
+
     assertThrows<InvalidRecipientFileException> {
-      Age.parseRecipients(reader("not-a-recipient"))
+      Age.parseRecipients(reader("$validRecipient\nnot-a-recipient"))
     }
   }
 


### PR DESCRIPTION
Ports age's own `parse.go`: read a keys.txt-style identity file or a recipients file, one key per line, blank lines and `#` comments skipped. Held this until #578 merged, since age's own `parse.go` recognizes X25519 and its hybrid PQ keys in the same switch statement rather than as separate concerns, so it made more sense to land both together than to ship an X25519-only version and immediately need a follow-up.

`Age.parseIdentities`/`Age.parseRecipients` take a `BufferedReader` and return a plain list of parsed keys (`List<Identity>`/`List<Recipient>`), recognizing both `X25519Identity`/`X25519Recipient` and the now-merged `MlKem768X25519Identity`/`MlKem768X25519Recipient`. An unrecognized line, or a file with nothing in it, throws `InvalidIdentityFileException`/`InvalidRecipientFileException`. Input is capped at 16 MiB, matching age's own limit.

Test fixtures are `age_test.go`'s own `TestParseIdentities` cases, plus hybrid PQ round trips age's own test suite doesn't cover yet.

Notes for review:
- New public API: `Age.parseIdentities`, `Age.parseRecipients`, `InvalidIdentityFileException`, `InvalidRecipientFileException`. In the `kage.api` diff.
- Verified with `./gradlew test checkKotlinAbi animalsnifferMain spotlessCheck`.
